### PR TITLE
Fix some bugs during my installation on Windows, mainly setup.py. Run schedule when no mode is specific.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft arknights_mower/resources
 graft arknights_mower/models
 graft arknights_mower/fonts
+graft arknights_mower/template

--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -226,9 +226,10 @@ def main(executable=False):
         
     if config_file is None:
         if executable:
-            # config_file = Path.home().joinpath('.ark_mower.yaml')
-            print(__rootdir__)
-            exit()  # TODO exe 版本的话配置文件默认和 exe 同目录
+            # print(f"executable:{sys.executable}")
+            # print(f"file: {sys.__file__}")
+            # print(f"MEIPASS: {sys._MEIPASS}")
+            config_file = Path(sys.executable).parent.joinpath('.ark_mower.yaml')
         else:
             config_file = Path.home().joinpath('.ark_mower.yaml')
         if not config_file.exists():

--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -211,6 +211,9 @@ def match_cmd(prefix, avail_cmds):
 
 def main(executable=False):
     args = sys.argv[1:]
+    if not args and executable:
+        args.append("schedule")
+        print("单文件模式，读取当前目录的.ark_mower.yaml文件执行计划任务。按下Ctrl+C以结束脚本运行")
     config_file = None
     debug_mode = False
     while True:

--- a/arknights_mower/utils/config.py
+++ b/arknights_mower/utils/config.py
@@ -53,23 +53,23 @@ def __set(path, value):
 
 
 def create_config(config_file):
-    with Path(f'{__rootdir__}/template/config.yaml').open('r') as f:
+    with Path(f'{__rootdir__}/template/config.yaml').open('r', encoding='utf8') as f:
         loader = yaml.load_all(f)
         next(loader)  # discard first document (used for comment)
         ydoc = next(loader)
-    with Path(config_file).open('w') as f:
+    with Path(config_file).open('w', encoding='utf8') as f:
         yaml.dump(ydoc, f)
 
 
 def load_config(config_file):
     global __ydoc
-    with Path(config_file).open('r') as f:
+    with Path(config_file).open('r', encoding='utf8') as f:
         __ydoc = yaml.load(f)
     init_config()
 
 
 def save_config(config_file):
-    with Path(config_file).open('w') as f:
+    with Path(config_file).open('w', encoding='utf8') as f:
         yaml.dump(__ydoc, f)
 
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,17 @@
+import os
+import sys
+
 from arknights_mower.__main__ import main
 
 if __name__ == '__main__':
-    main(executable=True)
+    try:
+        main(executable=True)
+    except Exception as e:
+        print(e)
+        print("脚本发生错误")
+        if sys.platform == "win32":
+            os.system("pause")
+        else:
+            input()
+        raise e
+    # Use sys.frozen to check if run through pyinstaller frozen exe, and sys._MEIPASS to get temp path.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 import arknights_mower
 
-LONG_DESC = open('README.md', 'r').read()
+LONG_DESC = open('README.md', 'r', encoding='utf8').read()
 VERSION = arknights_mower.__version__
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setuptools.setup(
     install_requires=['colorlog', 'opencv_python', 'matplotlib', 'numpy', 'scikit_image==0.18.3', 'scikit_learn>=1',
                       'onnxruntime', 'pyclipper', 'shapely', 'tornado', 'imagehash', 'requests', 'ruamel.yaml', 'schedule'],
     include_package_data=True,
-    package_data={'arknights_mower': ['template/*.yaml']},
     entry_points={'console_scripts': [
         'arknights-mower=arknights_mower.__main__:main']},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/Konano/arknights-mower',
     packages=setuptools.find_packages(),
-    install_requires=['colorlog', 'opencv_python', 'matplotlib', 'numpy', 'scikit_image', 'scikit_learn>=1',
+    install_requires=['colorlog', 'opencv_python', 'matplotlib', 'numpy', 'scikit_image==0.18.3', 'scikit_learn>=1',
                       'onnxruntime', 'pyclipper', 'shapely', 'tornado', 'imagehash', 'requests', 'ruamel.yaml', 'schedule'],
     include_package_data=True,
     package_data={'arknights_mower': ['template/*.yaml']},

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ setuptools.setup(
     url='https://github.com/Konano/arknights-mower',
     packages=setuptools.find_packages(),
     install_requires=['colorlog', 'opencv_python', 'matplotlib', 'numpy', 'scikit_image', 'scikit_learn>=1',
-                      'onnxruntime', 'pyclipper', 'shapely', 'tornado', 'imagehash', 'requests', 'ruamel.yaml'],
+                      'onnxruntime', 'pyclipper', 'shapely', 'tornado', 'imagehash', 'requests', 'ruamel.yaml', 'schedule'],
     include_package_data=True,
+    package_data={'arknights_mower': ['template/*.yaml']},
     entry_points={'console_scripts': [
         'arknights-mower=arknights_mower.__main__:main']},
     classifiers=[


### PR DESCRIPTION
Specific all open() using utf8 encoding to avoid build error on Windows Chinese version, which use gbk as default encoding.

And fix setup.py to add template files into package (not sure why include_package_data only work on images, not config files).
Also add missing dependency.

I've test `pip install .`  on Windows and Linux. You could test it by yourself before merge.