### PR TITLE
fix: improve robustness of agent arrangement

### DIFF
--- a/arknights_mower/solvers/base_construct.py
+++ b/arknights_mower/solvers/base_construct.py
@@ -632,7 +632,7 @@ class BaseConstructSolver(BaseSolver):
                         if self.scene() == Scene.INFRA_ARRANGE_CONFIRM:
                             x = self.recog.w // 3 * 2  # double confirm
                             y = self.recog.h - 10
-                            self.tap((x, y), rebuild=False)
+                            self.tap((x, y), rebuild=True)
                         finished = True
                         while self.scene() == Scene.CONNECTING:
                             self.sleep(3)


### PR DESCRIPTION
二次确认时，有时会报以下错误
如此修改后就可以了

```
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/ark/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/anaconda3/envs/ark/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/__main__.py", line 73, in <module>
    main(module=True)
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/__main__.py", line 64, in main
    target_cmd(args[1:], device)
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/command.py", line 51, in base
    BaseConstructSolver(device).run(arrange, clue_collect, drone_room, fia_room)
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/solvers/base_construct.py", line 51, in run
    super().run()
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/utils/solver.py", line 48, in run
    raise e
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/utils/solver.py", line 35, in run
    if self.transition():
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/solvers/base_construct.py", line 57, in transition
    return self.infra_main()
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/solvers/base_construct.py", line 90, in infra_main
    self.agent_arrange(self.arrange)
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/solvers/base_construct.py", line 636, in agent_arrange
    while self.scene() == Scene.CONNECTING:
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/utils/solver.py", line 162, in scene
    return self.recog.get_scene()
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/utils/recognize.py", line 65, in get_scene
    if self.find('connecting', scope=((self.w//2, self.h//10*8), (self.w//4*3, self.h))) is not None:
  File "/Users/mlw/Desktop/arknights-mower/arknights_mower/utils/recognize.py", line 250, in find
    ret = matcher.match(res_img, draw=draw, scope=scope, judge=judge)
AttributeError: 'NoneType' object has no attribute 'match'
```