### PR TITLE
自动打包dev_shawn分支

### DIFF
--- a/.github/workflows/pyinstaller-win-shawn.yml
+++ b/.github/workflows/pyinstaller-win-shawn.yml
@@ -1,0 +1,31 @@
+name: dev_shawn分支自动打包
+
+on:
+  push:
+    branches:
+      - dev_shawn
+
+jobs:
+  build-win-amd64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8 amd64
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Install dependencies
+        shell: cmd
+        run: |
+          python -m venv venv
+          venv\Scripts\python -m pip install -r requirements.txt
+          venv\Scripts\python -m pip install pyinstaller
+      - name: Make package
+        shell: cmd
+        run: |
+          venv\Scripts\pyinstaller .\menu.spec
+      - uses: actions/upload-artifact@v3
+        with:
+          name: mower
+          path: dist\mower.exe

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pandas==1.5.2
 pyyaml==6.0
 PySimpleGUI~=4.60.4
 pytz~=2022.6
-ruamel.yaml==0.15.46
+ruamel.yaml==0.17.22
 paddleocr==2.6.1.3
 paddlepaddle==2.4.2


### PR DESCRIPTION
- 旧版本的 ruamel.yaml 安装报错，因此升级了 ruamel.yaml 到最新版本；
- Python 版本是 3.8.10；
- 在 dev_shawn 分支推送时，自动构建 exe。