### PR TITLE
修正：加工站任务的垫刀材料检查及添加报错提示

### DIFF
--- a/arknights_mower/utils/scheduler_task.py
+++ b/arknights_mower/utils/scheduler_task.py
@@ -511,7 +511,7 @@ def try_workshop_tasks(op_data, tasks):
                         else:
                             if metadata.get("apCost", 0) == 4.0:
                                 non_base_material_4ap = True
-                            if metadata.get("apCost", 0) < 4.0:
+                            if 0.0 < metadata.get("apCost", 0) < 4.0:
                                 material_diandao = True
                 match = material_diandao and non_base_material_4ap
                 if not match:


### PR DESCRIPTION
修正：家具零件合成检查的道具不是“家具零件”而是“碳xx”。

修改：九色鹿加工任务条件为：至少一个垫刀材料和一个4心情非基建材料符合数量要求。

新增：不符合条件时报错提示