### PR TITLE
fix:修复请求维护时间报错导致死循环的问题

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -958,7 +958,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             seen = set()
             group = defaultdict(dict)
             for item in item_list:
-                for name in item.item_names:                    
+                for name in item.item_names:
                     if name in seen:
                         logger.warning(
                             f"当前干员{agent}的加工站配置中存在重复材料{item.item_names}，以第一个设置为准"

--- a/arknights_mower/utils/news_checker.py
+++ b/arknights_mower/utils/news_checker.py
@@ -46,9 +46,13 @@ class NewsChecker:
             return cls.cached_st, cls.cached_et
 
         # 3. 请求网页
-        response = requests.get(url, timeout=30)
-        response.encoding = "utf8"
-        soup = BeautifulSoup(response.text, "lxml")
+        try:
+            response = requests.get(url, timeout=30)
+            response.encoding = "utf8"
+            soup = BeautifulSoup(response.text, "lxml")
+        except Exception as e:
+            logger.error(f"请求维护时间出错：{e}")
+            return cls.cached_st, cls.cached_et
 
         for script_tag in soup.find_all("script"):
             text = script_tag.get_text()


### PR DESCRIPTION
由于main当中第一个任务就是查更新时间，如果查询报错会直接跳到exception，然后继续循环，导致死循环。因此改为如果查询失败就用缓存的时间。