### PR TITLE
feat(server): 添加退出接口用于退出程序

### DIFF
--- a/server.py
+++ b/server.py
@@ -769,3 +769,12 @@ def ws_chat(ws):
         except Exception as e:
             logger.exception(f"WebSocket处理错误：{str(e)}")
             ws.send(json.dumps({"error": str(e)}))
+
+
+@app.route("/exit")
+@require_token
+def exit():
+    config.parent_conn.send("exit")
+    if config.webview_process.join(3) is None:
+        config.webview_process.terminate()
+    return "true"

--- a/server.py
+++ b/server.py
@@ -775,6 +775,7 @@ def ws_chat(ws):
 @require_token
 def exit():
     config.parent_conn.send("exit")
-    if config.webview_process.join(3) is None:
+    config.webview_process.join(3)
+    if config.webview_process.is_alive():
         config.webview_process.terminate()
     return "true"

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -297,7 +297,8 @@ if __name__ == "__main__":
                     config.webview_process.start()
             elif msg == "exit":
                 config.parent_conn.send("exit")
-                if config.webview_process.join(3) is None:
+                config.webview_process.join(3)
+                if config.webview_process.is_alive():
                     config.webview_process.terminate()
                 break
     else:


### PR DESCRIPTION
新增exit路由接口，通过require_token装饰器保护，实现服务的退出功能。
当接收到退出请求时，会向父进程发送退出信号，并等待webview进程结束，
如果超时则强制终止进程，确保资源正确释放。