### PR TITLE
fix: 修复训练室干员选择状态问题

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -2596,7 +2596,12 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             else:
                 self.back_to_infrastructure()
 
-    def choose_train_ope(self, ope: str):
+    def choose_train_ope(self, ope: str, fast_mode=True):
+        if not fast_mode:
+            # 保证处于未选中任何干员状态
+            self.ctap((671, 908), 0.3)
+            self.ctap((671, 908), 0.3)
+
         found = False
         profession = "ALL"
         if ope != "阿米娅" and ope not in ["Current", "Free"]:
@@ -2767,6 +2772,10 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     self.switch_arrange_order("心情", room, "true")
                     pre_order = [3, "true"]
                 if not fast_mode:
+                    if room in ["train", "factory", "contact"]:
+                        # 没有清空选择按钮的单人房间手动清除
+                        self.ctap((self.recog.w * 0.35, self.recog.h * 0.75), 0.3)
+                        self.ctap((self.recog.w * 0.35, self.recog.h * 0.75), 0.3)
                     self.tap((self.recog.w * 0.38, self.recog.h * 0.95), interval=0.5)
                 changed, ret = self.scan_agent(
                     agent, full_scan=last_special_filter == "ALL"


### PR DESCRIPTION
在训练室和加工站等单人房间中，添加点击操作确保未选中任何干员状态
单人站没有清除选择按钮，在非fastmode下点击清除选择按钮位置无法正确清空选择状态。因此点击两次第二个干员位置来保证处于未选中干员状态。单人站的已选择干员必定在第一个位置，第一次点击第二个干员必定转移至已选中第二个干员状态，第二次点击第二个干员必定转移至未选中任何干员状态。