### PR TITLE
fix: 解决模拟器截图失败导致的日志洪波及频繁重启问题

### DIFF
--- a/arknights_mower/utils/device/device.py
+++ b/arknights_mower/utils/device/device.py
@@ -267,7 +267,7 @@ class Device:
                     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
                     break
                 except Exception as e:
-                    logger.exception(e)
+                    logger.error(e)
                     restart_simulator()
                     self.control.mumu12IPC = MuMu12IPC(self.device)
         elif config.conf.droidcast.enable:
@@ -284,7 +284,7 @@ class Device:
                     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
                     break
                 except Exception as e:
-                    logger.exception(e)
+                    logger.error(e)
                     restart_simulator()
                     self.client.check_server_alive()
                     Session().connect(config.conf.adb)
@@ -304,7 +304,7 @@ class Device:
                     )
                     break
                 except Exception as e:
-                    logger.exception(e)
+                    logger.error(e)
                     restart_simulator()
                     self.client.check_server_alive()
                     Session().connect(config.conf.adb)
@@ -319,7 +319,7 @@ class Device:
                     resp = self.run(command)
                     break
                 except Exception as e:
-                    logger.exception(e)
+                    logger.error(e)
                     restart_simulator()
                     self.client.check_server_alive()
                     Session().connect(config.conf.adb)


### PR DESCRIPTION
当前截图失败时，系统可能会在短时间内产生大量冗余的 traceback 日志（严重时 2 分钟内可达 25 万行以上）。这些日志缺乏诊断价值，不仅造成了大量的磁盘空间浪费与硬件损耗，还严重干扰了对核心问题的排查定位。

本 PR 主要从以下两个方面解决该问题：

1. 将日志等级由 exception 调整为 error，以屏蔽无效的 traceback 刷屏；
2. 引入重启回退机制，避免模拟器在异常状态下短时间内频繁重复重启。