### PR TITLE
增强登录流程稳定性并适配AVD环境

### DIFF
--- a/arknights_mower/utils/device/device.py
+++ b/arknights_mower/utils/device/device.py
@@ -142,7 +142,17 @@ class Device:
         if tap:
             self.run(f"input tap {x} {y}")
         else:
+            # 检查游戏是否在后台运行
+            in_background = self.is_app_running_in_background()
             self.run(f"am start -n {config.conf.APPNAME}/{config.APP_ACTIVITY_NAME}")
+            # 如果游戏之前不在后台（被 force-stop 过），发送 Overview 键激活 Activity
+            # 避免 am force-stop 后 am start 导致游戏卡在加载页面
+            if not in_background:
+                time.sleep(2)
+                logger.debug("发送 Overview 键激活游戏 Activity")
+                self.send_keyevent(187)  # KEYCODE_APP_SWITCH (Overview)
+                time.sleep(0.5)
+                self.send_keyevent(4)  # KEYCODE_BACK
 
     def exit(self) -> None:
         """exit the application"""

--- a/arknights_mower/utils/graph.py
+++ b/arknights_mower/utils/graph.py
@@ -422,6 +422,14 @@ class SceneGraphSolver(BaseSolver):
         error_count = 0
 
         while (current := self.scene()) != scene:
+            # 优先检测登录场景，调用完整登录流程
+            if current // 100 == 1:  # 登录场景 (100-199)
+                logger.info(
+                    f"检测到登录场景 {SceneComment.get(current, current)}，自动执行登录流程"
+                )
+                self.login()
+                continue
+
             if current in self.waiting_scene:
                 self.waiting_solver()
                 continue

--- a/arknights_mower/utils/recognize.py
+++ b/arknights_mower/utils/recognize.py
@@ -840,6 +840,7 @@ class Recognizer:
             "collection": (1005, 943),
             "collection_small": (1053, 982),
             "connecting": (1087, 978),
+            "login_awake": ((700, 650), (1200, 850)),
             "episode": (535, 937),
             "fight/use": (858, 864),
             "friend_list": (61, 306),

--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -529,19 +529,27 @@ class BaseSolver:
             try:
                 if (scene := self.scene()) == Scene.LOGIN_START:
                     # 应对两种情况：
-                    # 1. 点击左上角“网络检测”后出现“您即将进行一次网络拨测，该操作将采集您的网络状态并上报，点击确认继续”，点x
-                    # 2. 点击左上角“清除缓存”之后取消
-                    self.tap((665, 741))
+                    # 1. 点击左上角"网络检测"后出现"您即将进行一次网络拨测，该操作将采集您的网络状态并上报，点击确认继续"，点x
+                    # 2. 点击左上角"清除缓存"之后取消
+                    # AVD环境下scrcpy注入的触摸事件可能无效，使用ADB input tap命令
+                    self.device.run("input tap 1600 900")
+                    self.sleep(3)
                 elif scene == Scene.LOGIN_NEW:
                     self.tap_element("login_new")
+                    self.sleep(3)
                 elif scene == Scene.LOGIN_BILIBILI:
                     self.bilibili()
+                    self.sleep(3)
                 elif scene == Scene.LOGIN_BILIBILI_PRIVACY:
                     self.bilibili()
+                    self.sleep(3)
                 elif scene == Scene.LOGIN_QUICKLY:
-                    self.tap_element("login_awake")
+                    # AVD环境下scrcpy注入的触摸事件可能无效，使用ADB input tap命令
+                    self.device.run("input tap 958 766")
+                    self.sleep(3)
                 elif scene == Scene.LOGIN_MAIN:
                     self.tap_element("login_account", 0.25)
+                    self.sleep(3)
                 elif scene == Scene.LOGIN_REGISTER:
                     self.back(2)
                 elif scene == Scene.LOGIN_CAPTCHA:
@@ -570,7 +578,10 @@ class BaseSolver:
                 elif scene == Scene.LOGIN_ANNOUNCE:
                     self.tap_element("login_iknow")
                 elif scene in self.waiting_scene:
-                    self.waiting_solver()
+                    if not self.waiting_solver():
+                        retry_times -= 1
+                        self.sleep(3)
+                        continue
                 elif scene == Scene.CONFIRM:
                     self.tap((960, 740))
                 elif scene == Scene.LOGIN_CADPA_DETAIL:
@@ -593,6 +604,16 @@ class BaseSolver:
 
         if not self.is_login():
             raise StrategyError
+
+        # 登录成功后重新初始化 scrcpy-server
+        # 在 AVD 环境下，使用 ADB input tap 登录后 scrcpy 触摸注入可能失效
+        if self.device.control.scrcpy:
+            logger.info("登录成功，重新初始化 scrcpy-server")
+            try:
+                self.device.control.scrcpy.stop()
+                self.device.control.scrcpy.start()
+            except Exception as e:
+                logger.warning(f"scrcpy-server 重新初始化失败: {e}")
 
     def get_navigation(self):
         """


### PR DESCRIPTION
## 改进内容\n\n本PR包含两个登录相关的稳定性改进，基于最新的4.1.5分支：\n\n### 1. 避免am force-stop后am start导致游戏卡在加载页面 (commit 0888ee89)\n- 在device.py中添加了相关处理逻辑\n- 检测到游戏不在后台时，发送Overview键激活Activity，确保正常启动\n- 防止游戏在强制停止后重新启动时卡在加载页面\n\n### 2. 增强登录流程稳定性并适配AVD环境 (commit dad749b7)\n- 在场景图求解器中优先检测登录场景（100-199），自动触发完整登录流程\n- 更新recognize.py中login_awake的坐标定义为区域范围，提升识别鲁棒性\n- 在solver.py中针对AVD环境改用ADB input tap替代scrcpy触摸注入，避免点击失效\n- 登录各关键步骤后统一增加3秒等待，确保界面响应\n- 登录成功后自动重启scrcpy-server，修复AVD下触摸注入异常问题\n- waiting_solver调用失败时减少重试次数并继续循环，避免卡死\n\n## 测试建议\n- 在AVD环境下测试登录流程\n- 验证强制停止后重新启动的稳定性\n- 检查登录场景识别的准确性\n- 验证登录后的触摸操作是否正常\n\n## 影响范围\n- 登录流程相关代码\n- 设备控制逻辑\n- 场景识别模块\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)