### PR TITLE
feat: 完善森空岛签到功能并优化前端显示逻辑

### DIFF
--- a/arknights_mower/solvers/cultivate_depot.py
+++ b/arknights_mower/solvers/cultivate_depot.py
@@ -21,22 +21,21 @@ class cultivate:
         self.all_recorded = True
 
     def start(self):
-        for item in config.conf.skland_info:
-            if item.arknights_isCheck:
-                self.save_param(get_cred_by_token(log(item)))
-                for i in get_binding_list(self.sign_token):
-                    if item.cultivate_select == i.get("isOfficial"):
-                        body = {"gameId": 1, "uid": i.get("uid")}
-                        ingame = f"https://zonai.skland.com/api/v1/game/cultivate/player?uid={i.get('uid')}"
-                        resp = requests.get(
-                            ingame,
-                            headers=get_sign_header(
-                                ingame, "get", body, self.sign_token
-                            ),
-                            timeout=30,
-                        ).json()
-                        with open(self.record_path, "w", encoding="utf-8") as file:
-                            json.dump(resp, file, ensure_ascii=False, indent=4)
+        if not config.conf.skland_info:
+            return
+        item = config.conf.skland_info[0]
+        self.save_param(get_cred_by_token(log(item)))
+        for i in get_binding_list(self.sign_token):
+            if i.get("gameId") == 1 and item.cultivate_select == i.get("isOfficial"):
+                body = {"gameId": 1, "uid": i.get("uid")}
+                ingame = f"https://zonai.skland.com/api/v1/game/cultivate/player?uid={i.get('uid')}"
+                resp = requests.get(
+                    ingame,
+                    headers=get_sign_header(ingame, "get", body, self.sign_token),
+                    timeout=30,
+                ).json()
+                with open(self.record_path, "w", encoding="utf-8") as file:
+                    json.dump(resp, file, ensure_ascii=False, indent=4)
 
     def save_param(self, cred_resp):
         header["cred"] = cred_resp["cred"]

--- a/arknights_mower/solvers/depotREC.py
+++ b/arknights_mower/solvers/depotREC.py
@@ -3,6 +3,7 @@ import lzma
 import os
 import pickle
 import re
+import time
 from datetime import datetime
 
 import cv2
@@ -148,7 +149,11 @@ class depotREC(SceneGraphSolver):
     def 匹配物品一次(self, 物品, 物品灰, 模型名称):
         物品特征 = 提取特征点(物品)
         predicted_label = 模型名称.predict([物品特征])
-        物品数字 = self.读取物品数字(物品灰)
+
+        数字区域 = 物品灰[160:210, 30:210]  # 多加了一次裁切，把数字区域单独裁出来
+        物品数字 = self.读取物品数字(数字区域)  # 解决了合成玉只能识别3位数的问题
+
+        # 物品数字 = self.读取物品数字(物品灰)  # 这里是原来的逻辑
         return [predicted_label[0], 物品数字]
 
     def run(self) -> None:
@@ -162,7 +167,7 @@ class depotREC(SceneGraphSolver):
             self.tap_index_element("warehouse")
             logger.info("仓库扫描: 从主界面点击仓库界面")
 
-            time = datetime.now()
+            starttime = datetime.now()
             任务组 = [
                 (1200, self.knn模型_CONSUME, "消耗物品"),
                 (1400, self.knn模型_NORMAL, "基础物品"),
@@ -170,10 +175,11 @@ class depotREC(SceneGraphSolver):
 
             for 任务 in 任务组:
                 self.tap((任务[0], 70))
+                time.sleep(0.5)
                 if not self.find("depot_empty"):
                     self.分类扫描(任务[1])
                     logger.info(
-                        f"仓库扫描: {任务[2]}识别，识别用时{datetime.now() - time}"
+                        f"仓库扫描: {任务[2]}识别，识别用时{datetime.now() - starttime}"
                     )
                 else:
                     logger.info("仓库扫描: 这个分类下没有物品")

--- a/arknights_mower/solvers/skland.py
+++ b/arknights_mower/solvers/skland.py
@@ -32,17 +32,20 @@ class SKLand:
         self.test_writecsv = True
 
     def start(self):
+
         for item in config.conf.skland_info:
             if not (item.arknights_isCheck or item.endfield_isCheck):
                 continue
             if self.has_record(item.account):
                 continue
+
             self.all_recorded = False
             self.save_param(get_cred_by_token(log(item)))
+
             # 明日方舟森空岛签到
             for i in get_binding_list(self.sign_token):
                 if i["gameId"] == 1 and item.arknights_isCheck:
-                    if not i["uid"]:
+                    if not i.get("uid"):
                         continue
                     if not (item.sign_in_bilibili) and i["channelName"] == "bilibili服":
                         continue
@@ -83,8 +86,8 @@ class SKLand:
                         )
                 # 终末地森空岛签到
                 if i["gameId"] == 3 and item.endfield_isCheck:
-                    for j in i["roles"]:
-                        if not i["roles"]:
+                    for j in i.get("roles"):
+                        if not j.get("roleId"):
                             continue
                         if (
                             not (item.sign_in_endfield_bilibili)
@@ -124,7 +127,7 @@ class SKLand:
                             self.reward.append(
                                 {
                                     "nickname": item.account,
-                                    "game": "终末地",
+                                    "game": "终末地{}".format(i.get("channelName")),
                                     "reward": resp.get("message"),
                                 }
                             )
@@ -138,14 +141,14 @@ class SKLand:
                             self.reward.append(
                                 {
                                     "nickname": item.account,
-                                    "game": "终末地",
+                                    "game": "终末地{}".format(i.get("channelName")),
                                     "reward": "{}×{}".format(
                                         res["name"], res.get("count") or 1
                                     ),
                                 }
                             )
                             logger.info(
-                                f"{j.get('nickname')}获得了{res['name']}×{res.get('count') or 1}"
+                                f"{j.get('nickname')}的终末地{i.get('channelName')}获得了{res['name']}×{res.get('count') or 1}"
                             )
         if len(self.reward) > 0:
             return self.record_log()
@@ -217,8 +220,9 @@ class SKLand:
                         sign_arknights_official = True
                     if item[2] == "明日方舟bilibili服":
                         sign_arknights_bilbili = True
-                    if item[2] == "终末地":
+                    if item[2] == "终末地官服":
                         sign_endfield_official = True
+                    if item[2] == "终末地bilibili服":
                         sign_endfield_bilibili = True
                     if (
                         sign_arknights_official
@@ -238,41 +242,38 @@ class SKLand:
     def test_connect(self):
         res = []
         for item in config.conf.skland_info:
-            if item.arknights_isCheck or item.endfield_isCheck:
-                try:
-                    self.save_param(get_cred_by_token(log(item)))
-                    for i in get_binding_list(self.sign_token):
-                        if i["uid"] and i["gameId"] == 1:
+            try:
+                self.save_param(get_cred_by_token(log(item)))
+                res.append(f"账号 {item.account}：")
+                for i in get_binding_list(self.sign_token):
+                    # 明日方舟角色/区服信息
+                    if i["uid"] and i["gameId"] == 1:
+                        res.append(
+                            " - {}连接成功".format(
+                                i["nickName"] + "(明日方舟{})".format(i["channelName"])
+                            )
+                        )
+                    # 终末地角色/区服信息
+                    if i["roles"] and i["gameId"] == 3:
+                        for j in i["roles"]:
                             res.append(
-                                "{}连接成功".format(
-                                    i["nickName"] + "({})".format(i["channelName"])
+                                " - {}连接成功".format(
+                                    j["nickname"]
+                                    + "(终末地{})".format(i["channelName"])
                                 )
                             )
-                        # 从roles列表中获取终末地角色信息
-                        if i["roles"] and i["gameId"] == 3:
-                            for j in i["roles"]:
-                                res.append(
-                                    "{}连接成功".format(
-                                        j["nickname"]
-                                        + "(终末地{})".format(i["channelName"])
-                                    )
-                                )
-                except Exception as e:
-                    msg = "{}无法连接-{}".format(item.account, e)
-                    logger.exception(msg)
-                    res.append(msg)
+
+            except Exception as e:
+                msg = "{}无法连接-{}".format(item.account, e)
+                logger.exception(msg)
+                res.append(msg)
         return res
 
     # 用于测试签到
     def test_sign(self):
         res = []
+
         try:
-            for item in config.conf.skland_info:
-                if (not item.account or not item.password) and (
-                    item.arknights_isCheck or item.endfield_isCheck
-                ):
-                    res.append("账号{}配置不完整，请检查".format(item.account))
-                    return res
             if bool(self.start()):
                 for info in self.reward:
                     res.append(
@@ -282,14 +283,12 @@ class SKLand:
                         )
                     )
                 if not self.test_writecsv:
-                    res.append(
-                        "签到数据写入失败，可能是根目录下的tmp文件夹不存在或tmp/skland.csv被占用"
-                    )
+                    res.append("签到数据写入失败")
                     self.test_writecsv = True
                 return res
         except Exception as e:
             msg = "测试出错-{}".format(e)
             logger.exception(msg)
             res.append(msg)
-        res.append("未勾选有效的账号或勾选的账号今天已签到~")
+        res.append("勾选的账号今天均已签到~")
         return res

--- a/manager.py
+++ b/manager.py
@@ -56,7 +56,9 @@ class Api:
             Popen(["mower.exe", instance["path"], instance["name"]])
         else:
             if is_win:
-                Popen(["python.exe", "webview_ui.py", instance["path"], instance["name"]])
+                Popen(
+                    ["python.exe", "webview_ui.py", instance["path"], instance["name"]]
+                )
             else:
                 Popen(["python3", "webview_ui.py", instance["path"], instance["name"]])
 

--- a/ui/src/components/DailyMission.vue
+++ b/ui/src/components/DailyMission.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { useConfigStore } from '@/stores/config'
 import { storeToRefs } from 'pinia'
-import { inject, ref } from 'vue'
+import { inject, ref, computed } from 'vue'
 const axios = inject('axios')
 
 const store = useConfigStore()
@@ -16,6 +16,12 @@ async function test_sign() {
   const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/check-skland-sign`)
   sign_msg.value = response.data
 }
+
+const enable_test = computed(() => {
+  return skland_info.value.some((item) => {
+    return item.account?.trim() && item.password?.trim()
+  })
+})
 
 // 复选框逻辑
 // 账号勾选时相当于全选
@@ -45,6 +51,14 @@ const SyncStatus = (item, game) => {
     <n-flex vertical>
       <n-checkbox v-model:checked="skland_enable">
         <div class="item">森空岛签到</div>
+        <help-text>
+          <div>签到失败时，请尝试：</div>
+          <ol style="margin: 0">
+            <li>检查森空岛连接是否正常；</li>
+            <li>检查是否勾选了未绑定的区服/游戏</li>
+          </ol>
+          <div>Tips: 可以在根目录下的tmp/skland.csv中查看签到详情</div>
+        </help-text>
       </n-checkbox>
       <n-tabs type="line" animated>
         <n-tab-pane name="arknights" tab="明日方舟">
@@ -107,7 +121,7 @@ const SyncStatus = (item, game) => {
         </n-tab-pane>
       </n-tabs>
       <n-flex style="misc-container" align="center">
-        <n-button @click="test_sign">测试签到</n-button>
+        <n-button :disabled="!enable_test" @click="test_sign">测试签到</n-button>
         <div>{{ sign_msg }}</div>
       </n-flex>
       <n-divider />

--- a/ui/src/components/SKLand.vue
+++ b/ui/src/components/SKLand.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, ref } from 'vue'
+import { inject, ref, computed } from 'vue'
 const axios = inject('axios')
 
 import { useConfigStore } from '@/stores/config'
@@ -27,8 +27,14 @@ const maa_msg = ref('')
 async function test_maa() {
   maa_msg.value = '正在测试……'
   const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/check-skland`)
-  maa_msg.value = response.data
+  maa_msg.value = response.data.join('\n')
 }
+
+const enable_test = computed(() => {
+  return skland_info.value.some((item) => {
+    return item.account?.trim() && item.password?.trim()
+  })
+})
 </script>
 
 <template>
@@ -64,8 +70,15 @@ async function test_maa() {
       </template>
     </n-dynamic-input>
     <div class="misc-container">
-      <n-button @click="test_maa">测试设置</n-button>
-      <div>{{ maa_msg }}</div>
+      <n-button :disabled="!enable_test" @click="test_maa">测试设置</n-button>
+      <n-card
+        content-scrollable
+        style="max-height: 80px"
+        segmented
+        :content-style="{ whiteSpace: 'pre-line', overflow: 'auto' }"
+      >
+        <div>{{ maa_msg }}</div>
+      </n-card>
     </div>
   </n-card>
 </template>

--- a/ui/src/pages/RecordPie.vue
+++ b/ui/src/pages/RecordPie.vue
@@ -244,6 +244,11 @@ const onDrop = (index, event) => {
     const temp = reportData.value[index]
     reportData.value[index] = reportData.value[draggedIndex]
     reportData.value[draggedIndex] = temp
+
+    // 交换卡片同时交换展示的状态
+    const tempShow = showCard.value[index]
+    showCard.value[index] = showCard.value[draggedIndex]
+    showCard.value[draggedIndex] = tempShow
   }
   event.preventDefault()
 }

--- a/ui/src/pages/Settings.vue
+++ b/ui/src/pages/Settings.vue
@@ -162,7 +162,6 @@ const onSelectionChange = (newValue) => {
 import { ref } from 'vue'
 import ChatBotSetting from '../components/ChatBotSetting.vue'
 
-const idleAction = ref('') // 'home' | 'exit' | 'close'
 const showSettingModal = ref(false)
 const editingIndex = ref(null)
 
@@ -188,25 +187,43 @@ const workshop_setting_close = () => {
 }
 function createNewItem() {
   return {
-    item_names: [''],
+    item_names: [],
     children_lower_limit: 20,
     self_upper_limit: 20
   }
 }
+
+const idleAction = ref('') // 'idle' | 'home' | 'exit' | 'close'
+
+const idleOptions = [
+  { label: '无操作', value: 'idle' },
+  { label: '返回首页', value: 'home' },
+  { label: '退出游戏', value: 'exit' },
+  { label: '关闭模拟器', value: 'close' }
+]
+
 watch(idleAction, (val) => {
+  if (val == 'idle') {
+    return_home_when_idle.value = false
+    exit_game_when_idle.value = false
+    close_simulator_when_idle.value = false
+    return
+  }
   return_home_when_idle.value = val === 'home'
   exit_game_when_idle.value = val === 'exit'
   close_simulator_when_idle.value = val === 'close'
 })
+
 watch(
   [return_home_when_idle, exit_game_when_idle, close_simulator_when_idle],
   ([home, exit, close]) => {
     if (home) idleAction.value = 'home'
     else if (exit) idleAction.value = 'exit'
     else if (close) idleAction.value = 'close'
-    else idleAction.value = ''
+    else idleAction.value = 'idle'
   }
 )
+
 if (return_home_when_idle.value) {
   idleAction.value = 'home'
 } else if (exit_game_when_idle.value) {
@@ -214,7 +231,7 @@ if (return_home_when_idle.value) {
 } else if (close_simulator_when_idle.value) {
   idleAction.value = 'close'
 } else {
-  idleAction.value = ''
+  idleAction.value = 'idle'
 }
 </script>
 
@@ -283,7 +300,7 @@ if (return_home_when_idle.value) {
                 <span>模拟器文件夹</span>
                 <help-text>
                   <div>夜神：写到bin文件夹</div>
-                  <div>MuMu12: 写到shell文件夹</div>
+                  <div>MuMu12: 写到nx_main文件夹</div>
                 </help-text>
               </template>
               <n-input
@@ -342,23 +359,17 @@ if (return_home_when_idle.value) {
               <span class="coord-label">Y:</span>
               <n-input-number v-model:value="tap_to_launch_game.y" />
             </n-form-item>
-            <n-form-item :show-label="false">
-              <n-radio-group v-model:value="idleAction">
-                <n-space vertical>
-                  <n-radio value="home">
-                    任务结束后返回首页
-                    <help-text>降低功耗</help-text>
-                  </n-radio>
-                  <n-radio value="exit">
-                    任务结束后退出游戏
-                    <help-text>降低功耗</help-text>
-                  </n-radio>
-                  <n-radio value="close" v-if="simulator.name">
-                    任务结束后关闭模拟器
-                    <help-text>减少空闲时的资源占用、避免模拟器长时间运行出现问题</help-text>
-                  </n-radio>
-                </n-space>
-              </n-radio-group>
+            <n-form-item>
+              <template #label>
+                <span>任务结束后</span>
+                <help-text>
+                  <div>返回首页：降低功耗</div>
+                  <div>退出游戏：降低功耗</div>
+                  <div>关闭模拟器：减少空闲时的资源占用、避免模拟器长时间运行出现问题</div>
+                </help-text>
+              </template>
+
+              <n-select v-model:value="idleAction" :options="idleOptions" />
             </n-form-item>
             <n-form-item
               :show-label="false"
@@ -744,10 +755,8 @@ if (return_home_when_idle.value) {
                         </li>
                       </ul>
                     </div>
-                    <n-button text @click="openEdit(idx)">编辑</n-button>
-                    <n-button text type="error" @click="workshop_settings.splice(idx, 1)"
-                      >删除</n-button
-                    >
+                    <n-button @click="openEdit(idx)" style="margin-right: 20px">编辑</n-button>
+                    <n-button type="error" @click="workshop_settings.splice(idx, 1)">删除</n-button>
                   </div>
                 </n-list-item>
               </n-list>


### PR DESCRIPTION
### 新增：
- 增加森空岛签到时终末地区服的差分
- 美化森空岛登录测试连接的输出
- 增加森空岛签到测试的提示
- 调整 mower 设置中“任务结束后”相关设置的交互逻辑

### 修复：
- 修复森空岛读取仓库数据时被无效终末地数据覆盖的问题
- 修复仓库识别合成玉数量错误的问题
- 修正 mower 设置中模拟器文件夹的提示文本
- 修复无缝合成材料设置在新增设置时出现空 `dynamic-tag` 的情况
- 修复公休比报表中拖动饼图时展开状态无法同步更新的问题