### PR TITLE
fix: 修复了连战次数识别错误和理智获取错误的问题并为更新日志添加 markdown 渲染

### DIFF
--- a/arknights_mower/solvers/operation.py
+++ b/arknights_mower/solvers/operation.py
@@ -331,7 +331,7 @@ class OperationSolver(SceneGraphSolver):
                     self.auto_repeat = False
                     self.repeat_button_attempts = 0
                     return
-                repeat = self.number(((1520, 890), (1545, 930)), 28)
+                repeat = self.number(((1515, 870), (1545, 910)), 28)
                 logger.debug(
                     "operation repeat_status: repeat=%s auto_repeat=%s attempts=%s",
                     repeat,

--- a/arknights_mower/solvers/operation.py
+++ b/arknights_mower/solvers/operation.py
@@ -345,7 +345,7 @@ class OperationSolver(SceneGraphSolver):
                         self.desired_repeat_times,
                         repeat,
                     )
-                    self.tap((1500, 910), interval=0.5)
+                    # self.tap((1500, 910), interval=0.5) # 疑似多余点击
                     self.tap((1500, 801), interval=0.5)
                     self.auto_repeat = False
                     self.repeat_button_attempts = 0

--- a/arknights_mower/solvers/player_info.py
+++ b/arknights_mower/solvers/player_info.py
@@ -159,6 +159,11 @@ class PlayerInfoClient:
             return False
         if channel_name == "官服" and not item.sign_in_official:
             return False
+        # 读取第一个账户选择的森空岛仓库读取服务器作为理智获取服务器 true: official | false: bilibili
+        if item.cultivate_select and binding.get("channelName") != "官服":
+            return False
+        if not item.cultivate_select and binding.get("channelName") != "bilibili服":
+            return False
         return True
 
     def fetch_snapshot(self, item, binding: dict) -> PlayerInfoSnapshot:

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -64,16 +64,9 @@
                   {{ `从 ${updateNotice.previous_version} 更新` }}
                 </div>
                 <div
-                  style="
-                    margin-top: 16px;
-                    max-height: 50vh;
-                    overflow: auto;
-                    white-space: pre-wrap;
-                    line-height: 1.6;
-                  "
-                >
-                  {{ updateNotice.changelog }}
-                </div>
+                  style="margin-top: 16px; max-height: 50vh; overflow: auto; line-height: 1.6"
+                  v-html="renderedChangelog"
+                ></div>
                 <div style="margin-top: 20px; display: flex; justify-content: flex-end">
                   <n-button type="primary" @click="handleUpdateNoticeAck">我知道了</n-button>
                 </div>
@@ -213,7 +206,9 @@ import { NIcon } from 'naive-ui'
 import { storeToRefs } from 'pinia'
 import { h, inject, onMounted, provide, ref } from 'vue'
 import Feedback from '@/components/Feedback.vue'
+import markdownit from 'markdown-it'
 
+const md = markdownit({ html: true, breaks: true })
 const showModal = ref(false)
 const showModal2 = ref(false)
 const showFeedback = ref(false)
@@ -413,6 +408,10 @@ const mobile = ref(true)
 provide('mobile', mobile)
 
 const loaded = inject('loaded')
+
+const renderedChangelog = computed(() => {
+  return md.render(updateNotice.value.changelog)
+})
 
 async function handleUpdateNoticeAck() {
   if (!updateNotice.value.current_version) {


### PR DESCRIPTION
- 修正了连战次数识别的坐标
- 添加了服务器对齐的逻辑，修复了从森空岛获取理智信息的服务器与实际不一致的问题
- 使用 markdown-it 优化更新日志显示