### PR TITLE
Fix news checker handling of 24:00 maintenance end

### DIFF
--- a/arknights_mower/tests/news_checker_tests.py
+++ b/arknights_mower/tests/news_checker_tests.py
@@ -1,0 +1,31 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from arknights_mower.utils.news_checker import NewsChecker
+
+
+class TestNewsChecker(unittest.TestCase):
+    def test_build_update_time_accepts_24_hour_end(self):
+        news_tz = ZoneInfo("Asia/Shanghai")
+
+        start_dt, end_dt = NewsChecker._build_update_time(
+            2026, 5, 2, 16, 0, 24, 0, news_tz
+        )
+
+        self.assertEqual(start_dt, datetime(2026, 5, 2, 16, 0, tzinfo=news_tz))
+        self.assertEqual(end_dt, datetime(2026, 5, 3, 0, 0, tzinfo=news_tz))
+
+    def test_build_update_time_rolls_overnight_end_forward(self):
+        news_tz = ZoneInfo("Asia/Shanghai")
+
+        start_dt, end_dt = NewsChecker._build_update_time(
+            2026, 5, 2, 23, 0, 1, 30, news_tz
+        )
+
+        self.assertEqual(start_dt, datetime(2026, 5, 2, 23, 0, tzinfo=news_tz))
+        self.assertEqual(end_dt, datetime(2026, 5, 3, 1, 30, tzinfo=news_tz))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/news_checker.py
+++ b/arknights_mower/utils/news_checker.py
@@ -15,6 +15,15 @@ class NewsChecker:
     cached_et = None
     last_check_ts = None
 
+    @staticmethod
+    def _build_update_time(year, month, day, start_h, start_m, end_h, end_m, news_tz):
+        start_dt = datetime(year, month, day, start_h, start_m, tzinfo=news_tz)
+        end_dt = datetime(year, month, day, 0, 0, tzinfo=news_tz)
+        end_dt += timedelta(hours=end_h, minutes=end_m)
+        if end_dt <= start_dt:
+            end_dt += timedelta(days=1)
+        return start_dt, end_dt
+
     @classmethod
     def get_update_time(cls):
         host = "https://ak.hypergryph.com"
@@ -80,10 +89,16 @@ class NewsChecker:
                     start_h, start_m = int(m_time.group(4)), int(m_time.group(5))
                     end_h, end_m = int(m_time.group(6)), int(m_time.group(7))
 
-                    start_dt = datetime(
-                        year, month, day, start_h, start_m, tzinfo=news_tz
+                    start_dt, end_dt = cls._build_update_time(
+                        year,
+                        month,
+                        day,
+                        start_h,
+                        start_m,
+                        end_h,
+                        end_m,
+                        news_tz,
                     )
-                    end_dt = datetime(year, month, day, end_h, end_m, tzinfo=news_tz)
                     start_dt_local = start_dt.astimezone(local_tz).replace(tzinfo=None)
                     end_dt_local = end_dt.astimezone(local_tz).replace(tzinfo=None)
 


### PR DESCRIPTION
## Summary
- Normalize maintenance end times such as 24:00 to the next day 00:00
- Roll overnight maintenance end times forward when the end time is earlier than the start time
- Add unit tests for 24:00 and overnight maintenance windows

## Tests
- .venv/bin/python -m unittest arknights_mower.tests.news_checker_tests
- .venv/bin/python -m ruff check arknights_mower/utils/news_checker.py arknights_mower/tests/news_checker_tests.py
- .venv/bin/python -m ruff format --check arknights_mower/utils/news_checker.py arknights_mower/tests/news_checker_tests.py