### PR TITLE
fix: 处理闪断更新公告中的 24:00 时间解析错误

### DIFF
--- a/arknights_mower/utils/news_checker.py
+++ b/arknights_mower/utils/news_checker.py
@@ -83,7 +83,12 @@ class NewsChecker:
                     start_dt = datetime(
                         year, month, day, start_h, start_m, tzinfo=news_tz
                     )
-                    end_dt = datetime(year, month, day, end_h, end_m, tzinfo=news_tz)
+                    # 处理 24:00（表示第二天 00:00）
+                    if end_h == 24:
+                        end_h = 0
+                        end_dt = datetime(year, month, day, end_h, end_m, tzinfo=news_tz) + timedelta(days=1)
+                    else:
+                        end_dt = datetime(year, month, day, end_h, end_m, tzinfo=news_tz)
                     start_dt_local = start_dt.astimezone(local_tz).replace(tzinfo=None)
                     end_dt_local = end_dt.astimezone(local_tz).replace(tzinfo=None)
 


### PR DESCRIPTION
修复当明日方舟闪断更新公告时间为 `23:50~24:00` 格式时，`24:00` 不是合法 hour 值导致的 ValueError。

## 问题
公告时间格式如：`05月01日23:50 ~ 24:00`
Python datetime 中 hour 必须是 0-23，`24:00` 是非法值。

## 修复
将 `24:00` 转换为第二天 `00:00`，正确计算维护结束时间。

## 测试
- 输入：`2026-05-01 23:50 ~ 24:00`
- 输出：`2026-05-01 23:50 ~ 2026-05-02 00:00`