### PR TITLE
feat: 周计划关卡按开放时间过滤（基于4.1.6）

### DIFF
--- a/ui/src/components/MaaWeekly.vue
+++ b/ui/src/components/MaaWeekly.vue
@@ -71,6 +71,9 @@ const copyTargetDays = ref([])
 let copyDialogLongPressTimer = null
 let copyDialogLongPressTriggered = false
 
+// 关卡过滤开关（活动期间可关闭）
+const filterStageByAvailability = ref(true)
+
 const currentWeekdayIndex = computed(() => {
   const day = new Date().getDay()
   return day === 0 ? 6 : day - 1
@@ -82,6 +85,14 @@ const stageOptions = computed(() =>
     value
   }))
 )
+
+// 根据开关过滤关卡选项
+function filteredStageOptions(weekday) {
+  if (!filterStageByAvailability.value) {
+    return stageOptions.value
+  }
+  return stageOptions.value.filter((opt) => isStageAvailableOnWeekday(opt.value, weekday))
+}
 
 // --- 关卡可用性预计算 ---
 const stageAvailability = computed(() => {
@@ -322,17 +333,22 @@ function cancelCopyDialogLongPress() {
       label-align="left"
     >
       <n-form-item :show-label="false">
-        <n-flex class="weekly-plan-toolbar" align="center">
-          <n-checkbox v-model:checked="maa_expiring_medicine">使用将要过期的理智药</n-checkbox>
-          <n-checkbox
-            v-model:checked="exipring_medicine_on_weekend"
-            :disabled="!maa_expiring_medicine"
-          >
-            周末使用
-          </n-checkbox>
-          <div class="weekly-plan-selector-wrap">
-            <WeeklyPlanSelector compact />
-          </div>
+        <n-flex vertical :size="8">
+          <n-flex class="weekly-plan-toolbar" align="center">
+            <n-checkbox v-model:checked="maa_expiring_medicine">使用将要过期的理智药</n-checkbox>
+            <n-checkbox
+              v-model:checked="exipring_medicine_on_weekend"
+              :disabled="!maa_expiring_medicine"
+            >
+              周末使用
+            </n-checkbox>
+            <div class="weekly-plan-selector-wrap">
+              <WeeklyPlanSelector compact />
+            </div>
+          </n-flex>
+          <n-flex>
+            <n-checkbox v-model:checked="filterStageByAvailability">只显示当日开放关卡</n-checkbox>
+          </n-flex>
         </n-flex>
       </n-form-item>
     </n-form>
@@ -359,7 +375,7 @@ function cancelCopyDialogLongPress() {
               multiple
               filterable
               tag
-              :options="stageOptions"
+              :options="filteredStageOptions(plan.weekday)"
               :render-tag="renderStageTag(plan)"
               :on-create="createTag"
             />


### PR DESCRIPTION
## 功能说明

在"刷理智周计划"界面增加关卡开放时间过滤功能：

- 根据游戏内关卡开放时间表，自动过滤每日可刷的关卡
- 常驻关卡（上次作战、当期剿灭、1-7、经验书）每日可见
- 活动期间可通过开关关闭过滤，显示全部关卡
- 工具栏分两行布局，避免界面拥挤

## 改动内容

- 新增 `filterStageByAvailability` 开关控制关卡过滤
- 使用现有的 `time_table` 和 `isStageAvailableOnWeekday` 实现动态过滤
- 工具栏布局调整为两行显示（理智药选项 + 过滤开关）
- 下拉选项根据当日开放关卡动态过滤

## 已验证

- 各关卡按正确开放日期显示
- 开关关闭时显示全部关卡
- 界面布局正常