### PR TITLE
feat: 完善全自动专精功能

### DIFF
--- a/arknights_mower/data/training_route.json
+++ b/arknights_mower/data/training_route.json
@@ -1,0 +1,244 @@
+{
+  "先锋": {
+    "supports": [
+      {
+        "name": "夜半",
+        "skill_level": 1,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "缄默德克萨斯",
+        "skill_level": 2,
+        "efficiency": 80,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "凛御银灰",
+        "skill_level": 3,
+        "efficiency": 80,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      }
+    ],
+    "half_off": true
+  },
+  "近卫": {
+    "supports": [
+      {
+        "name": "赤冬",
+        "skill_level": 1,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "艾丽妮",
+        "match": true
+      },
+      {
+        "name": "燧石",
+        "skill_level": 2,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "艾丽妮",
+        "match": true
+      },
+      {
+        "name": "百炼嘉维尔",
+        "skill_level": 3,
+        "efficiency": 95,
+        "swap": true,
+        "swap_name": "艾丽妮",
+        "match": true
+      }
+    ],
+    "half_off": true
+  },
+  "重装": {
+    "supports": [
+      {
+        "name": "极光",
+        "skill_level": 1,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "暴雨",
+        "skill_level": 2,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "星熊",
+        "skill_level": 3,
+        "efficiency": 60,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      }
+    ],
+    "half_off": true
+  },
+  "狙击": {
+    "supports": [
+      {
+        "name": "假日威龙陈",
+        "skill_level": 1,
+        "efficiency": 95,
+        "swap": true,
+        "swap_name": "艾丽妮",
+        "match": true
+      },
+      {
+        "name": "埃拉托",
+        "skill_level": 2,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "艾丽妮",
+        "match": true
+      },
+      {
+        "name": "W",
+        "skill_level": 3,
+        "efficiency": 95,
+        "swap": true,
+        "swap_name": "艾丽妮",
+        "match": true
+      }
+    ],
+    "half_off": true
+  },
+  "术师": {
+    "supports": [
+      {
+        "name": "特米米",
+        "skill_level": 1,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": true
+      },
+      {
+        "name": "薄绿",
+        "skill_level": 2,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": true
+      },
+      {
+        "name": "死芒",
+        "skill_level": 3,
+        "efficiency": 95,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": true
+      }
+    ],
+    "half_off": true
+  },
+  "医疗": {
+    "supports": [
+      {
+        "name": "阿",
+        "skill_level": 1,
+        "efficiency": 60,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "濯尘芙蓉",
+        "skill_level": 2,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "阿",
+        "skill_level": 3,
+        "efficiency": 60,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      }
+    ],
+    "half_off": true
+  },
+  "辅助": {
+    "supports": [
+      {
+        "name": "铃兰",
+        "skill_level": 1,
+        "efficiency": 60,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": true
+      },
+      {
+        "name": "铃兰",
+        "skill_level": 2,
+        "efficiency": 60,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": true
+      },
+      {
+        "name": "浊心斯卡蒂",
+        "skill_level": 3,
+        "efficiency": 95,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": true
+      }
+    ],
+    "half_off": true
+  },
+  "特种": {
+    "supports": [
+      {
+        "name": "罗宾",
+        "skill_level": 1,
+        "efficiency": 75,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "缄默德克萨斯",
+        "skill_level": 2,
+        "efficiency": 80,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      },
+      {
+        "name": "归溟幽灵鲨",
+        "skill_level": 3,
+        "efficiency": 95,
+        "swap": true,
+        "swap_name": "逻各斯",
+        "match": false
+      }
+    ],
+    "half_off": true
+  },
+  "_backups": {
+    "先锋": "嵯峨",
+    "近卫": "史尔特尔",
+    "重装": "星熊",
+    "狙击": "黑",
+    "术师": "卡涅利安",
+    "医疗": "阿",
+    "辅助": "铃兰",
+    "特种": "傀影"
+  }
+}

--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -341,13 +341,20 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 self.check_current_focus()
         if self.error or force:
             # 如果没有任何时间小于当前时间的任务才生成空任务
-            if self.find_next_task(datetime.now()) is None:
+            if (
+                self.find_next_task(datetime.now()) is None
+                and self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE) is None
+            ):
                 logger.debug("由于出现错误情况，生成一次空任务来执行纠错")
                 self.tasks.append(SchedulerTask())
             # 如果没有任何时间小于当前时间的任务-10分钟 则清空任务
             if self.find_next_task(datetime.now() - timedelta(seconds=900)):
-                logger.info("检测到执行超过15分钟的任务，清空全部任务")
-                self.tasks = []
+                logger.info("检测到执行超过15分钟的任务，清空非专精任务")
+                self.tasks = [
+                    t
+                    for t in self.tasks
+                    if t.type in (TaskTypes.SKILL_UPGRADE, TaskTypes.REFRESH_TIME)
+                ]
         elif self.find_next_task(datetime.now() + timedelta(hours=2.5)) is None:
             logger.debug("2.5小时内没有其他任务，生成一个空任务")
             self.tasks.append(SchedulerTask(time=datetime.now() + timedelta(hours=2.5)))
@@ -897,6 +904,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                                 or self.op_data.operators[x].is_resting()
                             ):
                                 room = self.op_data.operators[x].room
+                                if room == "train" and (
+                                    self.find_next_task(
+                                        task_type=TaskTypes.SKILL_UPGRADE
+                                    )
+                                    or self._is_mastery_context()
+                                ):
+                                    continue
                                 if room not in fix_plan:
                                     fix_plan[room] = ["Current"] * len(plan[room])
                                 fix_plan[room][self.op_data.operators[x].index] = x
@@ -919,6 +933,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     self.skip()
                     return
                 else:
+                    if self._is_mastery_context():
+                        fix_plan.pop("train", None)
                     self.tasks.append(
                         SchedulerTask(
                             task_plan=fix_plan, task_type=TaskTypes.SELF_CORRECTION
@@ -959,6 +975,10 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     self.back()
                 if scene == Scene.TRAIN_SKILL_UPGRADE:
                     self.back()
+                if scene == Scene.TRAIN_FINISH:
+                    self.tap((self.recog.w * 0.05, self.recog.h * 0.95), interval=0.5)
+                    task.time = datetime.now()
+                    del tasks[0]
             self.back()
         except Exception as e:
             save_exception(e)
@@ -1262,12 +1282,17 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                                 ),
                                 use_digit_reader=True,
                             )
-                            if execute_time > datetime.now():
+                            if (
+                                execute_time is not None
+                                and execute_time > datetime.now()
+                                and execute_time < datetime.now() + timedelta(hours=25)
+                            ):
                                 self.tasks.append(
                                     SchedulerTask(
                                         time=execute_time,
                                         task_type=TaskTypes.SKILL_UPGRADE,
                                         meta_data=skill,
+                                        adjusted=True,
                                     )
                                 )
                                 return
@@ -1321,7 +1346,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 elif scene == Scene.TRAIN_SKILL_UPGRADE_ERROR:
                     # 如果材料不满足则会出现错误
                     if tasks[0] == "confirm":
-                        raise Exception("专精材料不足")
+                        logger.warning("专精材料不足，将在下次仓库扫描时自动重试")
+                        send_message(
+                            "专精材料不足，将在下次仓库扫描时自动重试",
+                            level="ERROR",
+                        )
+                        self.back()
+                        return
                     else:
                         self.back()
             if len(self.op_data.skill_upgrade_supports) > 0:
@@ -1336,7 +1367,11 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 h = self.op_data.calculate_switch_time(support)
                 if support is not None:
                     self.tasks.append(
-                        SchedulerTask(task_plan={"train": [support.name, "Current"]})
+                        SchedulerTask(
+                            task_plan={"train": [support.name, "Current"]},
+                            meta_data="_mastery",
+                            adjusted=True,
+                        )
                     )
                     # 提前10分钟换人，确保触发技能
                     # 3 级不需要换人
@@ -1348,6 +1383,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                             SchedulerTask(
                                 time=swap_time,
                                 task_plan={"train": [support.swap_name, "Current"]},
+                                meta_data="_mastery",
+                                adjusted=True,
                             )
                         )
                         self.tasks.append(
@@ -1378,6 +1415,11 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                             meta_data=skill,
                         )
                     )
+            else:
+                raise Exception(
+                    "未加载协助位干员数据，请检查 training_route.json 是否完整。"
+                    "如已配置自定义路线，请确认 matery_route.json 未被清空或损坏。"
+                )
             self.back()
         except Exception as e:
             logger.exception(e)
@@ -1616,7 +1658,60 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         # return adjust_0_room , adjust_0_room_len
         return adjust_0_room
 
+    def _check_mastery_plan_conflict(self):
+        conflicts = []
+        mastering = set()
+
+        plan = self._get_mastery_plan()
+        if plan:
+            try:
+                planned_ids = {k.split("_")[0] for k, v in plan.items() if v}
+                if planned_ids:
+                    from arknights_mower.utils.mastery_recommendation import (
+                        get_skill_data,
+                    )
+
+                    char_table = get_skill_data().get("characters", {})
+                    for cid in planned_ids:
+                        info = char_table.get(cid)
+                        if info:
+                            mastering.add(info.get("name", cid))
+            except Exception:
+                pass
+
+        for t in self.tasks:
+            if t.type == TaskTypes.SHIFT_ON:
+                for room, agents in t.plan.items():
+                    if "train" in room and len(agents) > 1 and agents[1] != "Current":
+                        mastering.add(agents[1])
+
+        if not mastering:
+            return []
+
+        for key in self.op_data.plan:
+            if "train" in key:
+                continue
+            for name in self.op_data.plan[key]:
+                if hasattr(name, "agent"):
+                    name = name.agent
+                if name in mastering:
+                    conflicts.append((name, key))
+
+        return conflicts
+
     def plan_solver(self):
+        conflicts = self._check_mastery_plan_conflict()
+        if conflicts:
+            msgs = [
+                f"{n} 在排班表 {r} 中，同时存在于专精计划/任务" for n, r in conflicts
+            ]
+            for m in msgs:
+                logger.error(m)
+            raise Exception(
+                f"检测到 {len(conflicts)} 个专精与排班冲突，请手动调整："
+                + "; ".join(f"{n}→{r}" for n, r in conflicts)
+            )
+
         # 准备数据
         logger.debug(self.op_data.print())
         # 根据剩余心情排序
@@ -2620,6 +2715,16 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     idx = select_targets[0][0]
                     self.ctap((self.recog.w * 0.82, self.recog.h * 0.18 * (idx + 1)))
                 continue
+            elif scene in (
+                Scene.TRAIN_SKILL_UPGRADE,
+                Scene.TRAIN_SKILL_SELECT,
+                Scene.TRAIN_FINISH,
+            ):
+                logger.info("训练室专精进行中，跳过换班")
+                return
+            elif scene == Scene.TRAIN_MAIN:
+                self.tap((self.recog.w * 0.25, self.recog.h * 0.95), interval=0.5)
+                continue
             elif scene == Scene.INFRA_ARRANGE_ORDER:
                 logger.info(tasks)
                 if tasks[0] == "scan":
@@ -3268,10 +3373,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 self.turn_on_room_detail(room)
                 error_count = 0
                 if not checked:
-                    if any(
-                        any(char in item for item in plan[room])
-                        for char in TRADE_ORDER_AGENTS
-                    ) and not room.startswith("dormitory"):
+                    if (
+                        any(
+                            any(char in item for item in plan[room])
+                            for char in TRADE_ORDER_AGENTS
+                        )
+                        and not room.startswith("dormitory")
+                        and room != "train"
+                    ):
                         new_plan[room] = self.refresh_current_room(room)
                     if "菲亚梅塔" in plan[room] and len(plan[room]) == 2:
                         new_plan[room] = self.refresh_current_room(room)
@@ -3339,6 +3448,10 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                             self.reset_room_time(room)
                             raise Exception("检测到漏单！")
                     if room == "train":
+                        if self._should_skip_train_room(self.task):
+                            self.get_agent_from_room("train")
+                            del plan[room]
+                            return new_plan
                         self.choose_train(plan[room], choose_error <= 0)
                     else:
                         while self.find("confirm_blue") is None:
@@ -3419,6 +3532,43 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 not_take = False
             self.tap((self.recog.w * 0.25, self.recog.h * 0.25), interval=0.5)
 
+    def _get_mastery_plan(self):
+        plan_path = get_path("@app/tmp/matery_plan.json")
+        if os.path.exists(plan_path):
+            try:
+                with open(plan_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception:
+                return {}
+        return {}
+
+    def _is_mastery_context(self):
+        if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+            return True
+        try:
+            from arknights_mower.solvers.player_info import player_info_cache
+
+            latest = player_info_cache.get("latest", {})
+            training = (
+                latest.get("building_training") if isinstance(latest, dict) else None
+            )
+            if training is not None:
+                return isinstance(training.get("trainee"), dict)
+        except Exception:
+            pass
+        return False
+
+    def _should_skip_train_room(self, task):
+        if task.meta_data == "_mastery":
+            return False
+        if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+            logger.info("有未完成的专精任务，跳过训练室排班")
+            return True
+        if self._is_mastery_context():
+            logger.info("训练室专精进行中，跳过非专精排班")
+            return True
+        return False
+
     def agent_arrange(self, plan: tp.BasePlan, get_time=False):
         logger.info("基建：排班")
         rooms = list(plan.keys())
@@ -3432,7 +3582,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         )
         for room in rooms:
             new_plan = self.agent_arrange_room(new_plan, room, plan, get_time=get_time)
-        if len(new_plan) == 1:
+        if len(new_plan) == 1 and room != "train":
             if config.conf.run_order_buffer_time <= 0 or self.task.adjusted:
                 if self.task.adjusted:
                     logger.info("检测到跑单已调整，强制使用无人机跑单")
@@ -4393,6 +4543,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 else:
                     logger.info("local operation finished without executing any stage")
 
+            scheduling(self.tasks)
             remaining_time = (self.tasks[0].time - datetime.now()).total_seconds()
             self.handle_idle_action(remaining_time)
             subject = (
@@ -4464,6 +4615,12 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     def 仓库扫描(self):
         try:
             cultivateDepotSolver().start()
+            try:
+                from arknights_mower.solvers.player_info import PlayerInfoClient
+
+                PlayerInfoClient().get_first_available_snapshot()
+            except Exception:
+                pass
             DepotSolver(self.device, self.recog).run()
             self._auto_schedule_mastery_after_scan()
         except Exception as e:
@@ -4471,6 +4628,106 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             logger.exception(f"先不运行 出bug了 : {e}")
             return False
         return True
+
+    def _verify_and_recover_mastery_room(self):
+        """用 SKLand 训练室数据验证、纠错并恢复丢失的专精任务"""
+        try:
+            from arknights_mower.solvers.player_info import player_info_cache
+            from arknights_mower.utils.mastery_recommendation import (
+                _build_route_supports,
+                get_skill_data,
+            )
+            from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
+
+            latest = player_info_cache.get("latest", {})
+            training = (
+                latest.get("building_training") if isinstance(latest, dict) else None
+            )
+            if not training:
+                return
+
+            trainee = training.get("trainee")
+            trainer = training.get("trainer")
+
+            if not isinstance(trainee, dict):
+                return
+
+            if training.get("remainSecs", 0) <= 0:
+                return
+
+            trainee_cid = trainee.get("charId")
+            target_skill = trainee.get("targetSkill")
+            if not trainee_cid or target_skill is None:
+                return
+
+            char_table = get_skill_data().get("characters", {})
+            trainee_name = char_table.get(trainee_cid, {}).get("name", trainee_cid)
+            trainee_skill_label = str(target_skill + 1)
+
+            plan_has_trainee = False
+            matery_plan = self._get_mastery_plan()
+            if matery_plan:
+                try:
+                    plan_key = f"{trainee_cid}_{target_skill}"
+                    if matery_plan.get(plan_key):
+                        plan_has_trainee = True
+                except Exception:
+                    pass
+
+            supports_list = self.op_data.skill_upgrade_supports
+            if not supports_list and matery_plan:
+                try:
+                    trainee_info = char_table.get(trainee_cid, {})
+                    profession = trainee_info.get("profession", "")
+                    if profession:
+                        from arknights_mower.utils.mastery_recommendation import (
+                            _supports_from_dicts,
+                        )
+
+                        route = _build_route_supports(profession)
+                        if route:
+                            supports_list = _supports_from_dicts(route)
+                except Exception as e:
+                    logger.warning(f"恢复时加载专精路线失败: {e}")
+
+            if trainer and isinstance(trainer, dict) and supports_list:
+                trainer_cid = trainer.get("charId")
+                trainer_name = (
+                    char_table.get(trainer_cid, {}).get("name", trainer_cid)
+                    if trainer_cid
+                    else ""
+                )
+                support_names = {s.name for s in supports_list}
+                if trainer_name and trainer_name not in support_names:
+                    logger.warning(
+                        f"协助位干员 {trainer_name} 不在支持列表中，下次换人会纠正"
+                    )
+
+            if not plan_has_trainee and not self.find_next_task(meta_data="_mastery"):
+                logger.error(
+                    f"训练位干员 {trainee_name} skill_{trainee_skill_label}"
+                    f" 不在专精计划和一键专精上下文中"
+                )
+                return
+
+            sk = trainee_skill_label
+            if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE, meta_data=sk):
+                return
+
+            logger.info(
+                f"从森空岛恢复专精任务: {trainee_name} skill_{sk}"
+                f" (charId={trainee_cid}, targetSkill={target_skill})"
+            )
+            self.tasks.append(
+                SchedulerTask(
+                    time=datetime.now(),
+                    task_type=TaskTypes.SKILL_UPGRADE,
+                    meta_data=sk,
+                    adjusted=True,
+                )
+            )
+        except Exception:
+            pass
 
     def _auto_schedule_mastery_after_scan(self):
         try:
@@ -4481,16 +4738,46 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
 
             res = auto_schedule_mastery_tasks()
+            self._verify_and_recover_mastery_room()
             for entry in res.get("scheduled", []):
+                sk = str(entry["skill_index"] + 1)
                 has = self.find_next_task(
                     task_type=TaskTypes.SKILL_UPGRADE,
-                    meta_data=str(entry["skill_index"] + 1),
+                    meta_data=sk,
                 )
                 if not has:
+                    if not self.op_data.skill_upgrade_supports:
+                        try:
+                            from arknights_mower.utils.mastery_recommendation import (
+                                _build_route_supports,
+                                _supports_from_dicts,
+                            )
+
+                            supports = _supports_from_dicts(
+                                _build_route_supports(entry["profession"])
+                            )
+                            self.op_data.skill_upgrade_supports = supports
+                        except Exception as e:
+                            logger.warning(f"加载专精路线失败: {e}")
+                    first_support = ""
+                    if self.op_data.skill_upgrade_supports:
+                        first_support = self.op_data.skill_upgrade_supports[0].name
+                    if first_support:
+                        self.tasks.append(
+                            SchedulerTask(
+                                task_plan={"train": [first_support, entry["name"]]},
+                                meta_data="_mastery",
+                            )
+                        )
+                    else:
+                        logger.warning(
+                            f"无法为 {entry['name']} 生成训练室换人任务，支持列表为空"
+                        )
                     self.tasks.append(
                         SchedulerTask(
                             task_type=TaskTypes.SKILL_UPGRADE,
-                            meta_data=str(entry["skill_index"] + 1),
+                            meta_data=sk,
+                            adjusted=True,
                         )
                     )
                     logger.info(f"自动安排专精: {entry['name']} {entry['skill_name']}")

--- a/arknights_mower/solvers/depotREC.py
+++ b/arknights_mower/solvers/depotREC.py
@@ -137,13 +137,10 @@ class depotREC(SceneGraphSolver):
                 str(结果[k]) if 结果[k] < 10 else ("万" if 结果[k] == 10 else ".")
             )
 
-        if not 物品个数:
-            return 999999
-        # # 格式化数字
-        格式化数字 = int(
-            float("".join(re.findall(r"\d+\.\d+|\d+", 物品个数)))
-            * (10000 if "万" in 物品个数 else 1)
-        )
+        matches = re.findall(r"\d+\.\d+|\d+", 物品个数)
+        if not matches:
+            return None
+        格式化数字 = int(float("".join(matches)) * (10000 if "万" in 物品个数 else 1))
         return 格式化数字
 
     def 匹配物品一次(self, 物品, 物品灰, 模型名称):
@@ -220,5 +217,8 @@ class depotREC(SceneGraphSolver):
 
         for [物品, 物品灰, id] in 切图列表:
             [物品名称, 物品数字] = self.匹配物品一次(物品, 物品灰, 模型名称)
+            if 物品数字 is None:
+                logger.warning(f"仓库扫描: 无法识别 {物品名称} 的数量，跳过")
+                continue
             logger.debug([物品名称, 物品数字])
             self.结果字典[物品名称] = self.结果字典.get(物品名称, 0) + 物品数字

--- a/arknights_mower/solvers/player_info.py
+++ b/arknights_mower/solvers/player_info.py
@@ -31,6 +31,7 @@ class PlayerInfoSnapshot:
     full_recovery_time: datetime.datetime
     fetched_at: datetime.datetime
     raw_ap: dict
+    building_training: dict | None = None
 
 
 class PlayerInfoClient:
@@ -204,6 +205,7 @@ class PlayerInfoClient:
             full_recovery_time=full_recovery_time,
             fetched_at=datetime.datetime.now(datetime.timezone.utc),
             raw_ap=ap,
+            building_training=resp.get("data", {}).get("building", {}).get("training"),
         )
         cache_key = f"{snapshot.account}:{snapshot.uid}"
         player_info_cache[cache_key] = asdict(snapshot)

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -16,6 +16,21 @@ def _find_skill_data():
     return candidates[0]
 
 
+_skill_data_cache = None
+
+
+def get_skill_data():
+    global _skill_data_cache
+    if _skill_data_cache is None:
+        path = _find_skill_data()
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                _skill_data_cache = json.load(f)
+        else:
+            _skill_data_cache = {}
+    return _skill_data_cache
+
+
 def _decompose_to_t3(materials, composite, item_table, inventory):
     """将 T4/T5 材料拆解为 T3 级别材料，并与仓库库存对比"""
     raw = {}
@@ -461,6 +476,77 @@ def compute_workshop_config(t5_operator="年", book_operator="司霆惊蛰"):
     ]
 
 
+_default_route_cache = None
+
+
+def _load_default_route():
+    global _default_route_cache
+    if _default_route_cache is not None:
+        return _default_route_cache
+    path = get_path("@internal/arknights_mower/data/training_route.json")
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                _default_route_cache = json.load(f)
+        except Exception:
+            _default_route_cache = {}
+    else:
+        _default_route_cache = {}
+    return _default_route_cache
+
+
+def _build_route_supports(profession, control_center="none"):
+    defaults = _load_default_route()
+    prof_cn = PROF_MAP.get(profession, "近卫")
+    route_path = get_path("@app/tmp/matery_route.json")
+    if os.path.exists(route_path):
+        try:
+            with open(route_path, "r", encoding="utf-8") as f:
+                route = json.load(f)
+        except Exception:
+            route = {}
+    else:
+        route = {}
+    prof_default = defaults.get(prof_cn, {})
+    prof_route = route.get(prof_cn, prof_default)
+    supports_data = prof_route.get("supports", []) or prof_default.get("supports", [])
+    half_off = prof_route.get("half_off", prof_default.get("half_off", True))
+    cc = control_center or prof_route.get(
+        "controlCenter", prof_default.get("controlCenter", "none")
+    )
+    bonus = 0 if cc == "none" else 5
+    supports = []
+    for s in supports_data:
+        supports.append(
+            {
+                "name": s["name"],
+                "skill_level": s["skill_level"],
+                "efficiency": min(100, s["efficiency"] + bonus),
+                "match": s.get("match", False),
+                "swap_name": s.get("swap_name") if s.get("swap") else s["name"],
+                "half_off": half_off,
+            }
+        )
+    return supports
+
+
+def _supports_from_dicts(supports_data):
+    from arknights_mower.utils.operators import SkillUpgradeSupport
+
+    supports = []
+    for s in supports_data:
+        sup = SkillUpgradeSupport(
+            name=s["name"],
+            skill_level=s["skill_level"],
+            efficiency=s["efficiency"],
+            match=s.get("match", False),
+            swap_name=s.get("swap_name", s["name"]),
+        )
+        sup.half_off = s.get("half_off", True)
+        supports.append(sup)
+    return supports
+
+
 def auto_schedule_mastery_tasks():
     """仓库扫描后：检测计划内未满M3的技能，直接需求全部满足则返回待安排列表"""
     result = {"scheduled": [], "skipped": []}
@@ -549,3 +635,15 @@ def auto_schedule_mastery_tasks():
                 result["skipped"].append(entry)
 
     return result
+
+
+PROF_MAP = {
+    "WARRIOR": "近卫",
+    "SNIPER": "狙击",
+    "TANK": "重装",
+    "MEDIC": "医疗",
+    "SUPPORT": "辅助",
+    "CASTER": "术师",
+    "SPECIAL": "特种",
+    "PIONEER": "先锋",
+}

--- a/arknights_mower/utils/scheduler_task.py
+++ b/arknights_mower/utils/scheduler_task.py
@@ -164,10 +164,16 @@ def scheduling(tasks, run_order_delay=5, execution_time=0.75, time_now=None):
                         timedelta(minutes=total_execution_time) + time_now
                         > tasks[next_priority_0_index].time
                     ):
+                        if (tasks[next_priority_0_index].time - time_now) > timedelta(
+                            minutes=10
+                        ):
+                            break
                         logger.info("检测到任务可能影响到下次跑单修改任务至跑单之后")
                         logger.debug("||".join([str(t) for t in tasks]))
                         next_priority_0_time = tasks[next_priority_0_index].time
                         for j in range(i, next_priority_0_index):
+                            if tasks[j].adjusted:
+                                continue
                             tasks[j].time = next_priority_0_time + timedelta(seconds=1)
                             next_priority_0_time = tasks[j].time
                         logger.debug("||".join([str(t) for t in tasks]))

--- a/server.py
+++ b/server.py
@@ -1035,6 +1035,34 @@ def workshop_preset():
         return {"success": True}
 
 
+@app.route("/mastery-route", methods=["GET", "POST"])
+def mastery_route():
+    import json as _json
+
+    route_path = get_path("@app/tmp/matery_route.json")
+    if request.method == "GET":
+        if os.path.exists(route_path):
+            try:
+                with open(route_path, "r", encoding="utf-8") as f:
+                    return _json.load(f)
+            except Exception:
+                pass
+        default_path = get_path("@internal/arknights_mower/data/training_route.json")
+        if os.path.exists(default_path):
+            try:
+                with open(default_path, "r", encoding="utf-8") as f:
+                    return _json.load(f)
+            except Exception:
+                pass
+        return {}
+    else:
+        data = request.json or {}
+        route_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(route_path, "w", encoding="utf-8") as f:
+            _json.dump(data, f, ensure_ascii=False)
+        return {"success": True}
+
+
 @app.route("/cultivate-fetch")
 def cultivate_fetch():
     from arknights_mower.solvers.cultivate_depot import cultivate
@@ -1082,7 +1110,7 @@ def add_task():
                         raise Exception("找到同时间任务请勿重复添加")
                     if new_task.type == TaskTypes.SKILL_UPGRADE:
                         supports = []
-                        for s in req["upgrade_support"]:
+                        for s in req.get("upgrade_support", []):
                             if (
                                 s["name"] not in agent_list
                                 or s["swap_name"] not in agent_list

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -735,121 +735,69 @@ const controlCenterOptions = [
 const controlCenter = ref('none')
 const controlCenterBonus = computed(() => (controlCenter.value === 'none' ? 0 : 5))
 
-const t60 = {
-  先锋: { name: '嵯峨', speed: 60 },
-  近卫: { name: '史尔特尔', speed: 60 },
-  重装: { name: '星熊', speed: 60 },
-  狙击: { name: '黑', speed: 60 },
-  术师: { name: '卡涅利安', speed: 60 },
-  医疗: { name: '阿', speed: 60 },
-  辅助: { name: '铃兰', speed: 60 },
-  特种: { name: '傀影', speed: 60 }
-}
-const t1 = {
-  先锋: { name: '夜半', speed: 75 },
-  近卫: { name: '赤冬', speed: 75 },
-  重装: { name: '极光', speed: 75 },
-  狙击: { name: '假日威龙陈', speed: 95 },
-  术师: { name: '特米米', speed: 75 },
-  医疗: { name: '阿', speed: 60 },
-  辅助: { name: '铃兰', speed: 60 },
-  特种: { name: '罗宾', speed: 75 }
-}
-const t2 = {
-  先锋: { name: '缄默德克萨斯', speed: 80 },
-  近卫: { name: '燧石', speed: 75 },
-  重装: { name: '暴雨', speed: 75 },
-  狙击: { name: '埃拉托', speed: 75 },
-  术师: { name: '薄绿', speed: 75 },
-  医疗: { name: '濯尘芙蓉', speed: 75 },
-  辅助: { name: '铃兰', speed: 60 },
-  特种: { name: '缄默德克萨斯', speed: 80 }
-}
-const t3 = {
-  先锋: { name: '嵯峨', speed: 60 },
-  近卫: { name: '百炼嘉维尔', speed: 95 },
-  重装: { name: '星熊', speed: 60 },
-  狙击: { name: 'W', speed: 95 },
-  术师: { name: '死芒', speed: 95 },
-  医疗: { name: '阿', speed: 60 },
-  辅助: { name: '浊心斯卡蒂', speed: 95 },
-  特种: { name: '归溟幽灵鲨', speed: 95 }
-}
+const defaultsCache = ref(null)
 
-const defaultRoute = (p) => ({
-  supports: [
-    {
-      name: t1[p].name,
-      skill_level: 1,
-      efficiency: t1[p].speed,
-      swap: true,
-      swap_name: ['近卫', '狙击'].includes(p) ? '艾丽妮' : '逻各斯',
-      match: ['近卫', '狙击', '术师', '辅助'].includes(p)
-    },
-    {
-      name: t2[p].name,
-      skill_level: 2,
-      efficiency: t2[p].speed,
-      swap: true,
-      swap_name: ['近卫', '狙击'].includes(p) ? '艾丽妮' : '逻各斯',
-      match: ['近卫', '狙击', '术师', '辅助'].includes(p)
-    },
-    {
-      name: t3[p].name,
-      skill_level: 3,
-      efficiency: t3[p].speed,
-      swap: true,
-      swap_name: ['近卫', '狙击'].includes(p) ? '艾丽妮' : '逻各斯',
-      match: ['近卫', '狙击', '术师', '辅助'].includes(p)
-    }
-  ],
-  optimal: false,
-  half_off: true
-})
-const copyR = (r) => ({
-  supports: r.supports.map((s) => ({ ...s })),
-  optimal: r.optimal,
-  half_off: r.half_off
-})
-const routeSettings = reactive(Object.fromEntries(profKeys.map((p) => [p, copyR(defaultRoute(p))])))
+const routeSettings = reactive(
+  Object.fromEntries(profKeys.map((p) => [p, { supports: [], half_off: true }]))
+)
 
 function newSupport(p) {
   const n = routeSettings[p].supports.length
   if (n >= 3) return null
-  const i = n + 1,
-    opt = routeSettings[p].optimal
-  const s = opt ? (i === 1 ? t1[p] : i === 2 ? t2[p] : t3[p]) : i === 3 ? t3[p] : t60[p]
-  return {
-    name: s.name,
-    skill_level: i,
-    efficiency: s.speed,
-    swap: true,
-    swap_name: ['近卫', '狙击'].includes(p) ? '艾丽妮' : '逻各斯',
-    match: ['近卫', '狙击', '术师', '辅助'].includes(p)
+  const i = n + 1
+  const def = defaultsCache.value
+  if (!def) return null
+  if (!routeSettings[p].optimal) {
+    const backups = def._backups || {}
+    const name = backups[p] || ''
+    if (!name) return null
+    return { name, skill_level: i, efficiency: 60, swap: true, swap_name: name, match: false }
   }
+  const ref = def[p]?.supports?.find((s) => s.skill_level === i)
+  if (!ref) return null
+  return { ...ref, swap: true }
 }
 
-function loadRoute() {
-  try {
-    const d = JSON.parse(localStorage.getItem(ROUTE_KEY) || '{}')
-    for (const p of profKeys) {
-      if (d[p]) {
-        routeSettings[p].supports = d[p].supports || routeSettings[p].supports
-        routeSettings[p].optimal = !!d[p].optimal
-        routeSettings[p].half_off = d[p].half_off !== undefined ? d[p].half_off : true
-      }
+function applyRoute(d) {
+  for (const p of profKeys) {
+    if (d[p]) {
+      routeSettings[p].supports = d[p].supports || routeSettings[p].supports
+      routeSettings[p].optimal = !!d[p].optimal
+      routeSettings[p].half_off = d[p].half_off !== undefined ? d[p].half_off : true
     }
-    if (d.controlCenter) controlCenter.value = d.controlCenter
+  }
+  if (d.controlCenter) controlCenter.value = d.controlCenter
+}
+
+async function loadRoute() {
+  try {
+    const local = JSON.parse(localStorage.getItem(ROUTE_KEY) || '{}')
+    applyRoute(local)
+  } catch {}
+  try {
+    const r = await axios.get(`${import.meta.env.VITE_HTTP_URL}/mastery-route`)
+    const data = r.data || {}
+    defaultsCache.value = data
+    applyRoute(data)
   } catch {}
 }
 function saveRoute() {
   const toSave = { ...routeSettings, controlCenter: controlCenter.value }
   localStorage.setItem(ROUTE_KEY, JSON.stringify(toSave))
+  axios.post(`${import.meta.env.VITE_HTTP_URL}/mastery-route`, toSave).catch(() => {})
   message.success('已保存')
   showSettings.value = false
 }
 function resetRoute() {
-  for (const p of profKeys) Object.assign(routeSettings[p], copyR(defaultRoute(p)))
+  const def = defaultsCache.value
+  if (!def) return
+  for (const p of profKeys) {
+    if (def[p]?.supports) {
+      routeSettings[p].supports = def[p].supports.map((s) => ({ ...s }))
+      routeSettings[p].half_off = def[p].half_off !== undefined ? def[p].half_off : true
+      routeSettings[p].optimal = !!def[p].optimal
+    }
+  }
   message.info('已恢复默认')
 }
 


### PR DESCRIPTION
## 主要改动

### 全自动专精执行链路
- 默认自动从 training_route.json 加载最优训练路线并设置协助干员
- 自动创建 SHIFT_ON 初始化训练室
- supports 完全为空时抛异常并通过邮件告警

### 训练室保护
- 心情纠错跳过训练室
- 排班流程跳过训练室
- 纠错任务排除训练室
- 任务清理保留专精任务
- 训练场景守卫

### 重启恢复
- `_verify_and_recover_mastery_room` 在仓库扫描后运行
- 从 SKLand 实时数据读取训练室状态
- 检测到训练中但任务列表中无对应任务时自动恢复 SKILL_UPGRADE

### 排班冲突检测
- `_check_mastery_plan_conflict` 在 `plan_solver` 前执行
- 专精计划中的干员同时出现在基建排班表时阻止排班

### 数据架构
- 新增 `data/training_route.json`：唯一最优训练路线数据源
- 前端删除 `t1/t2/t3/t60` 硬编码表，通过 API 加载
- 新增 `/mastery-route` 端点持久化用户路线配置

### 其他修复
- `depotREC.py`: OCR 空值改为跳过
- `scheduler_task.py`: `adjusted` 标记 + 10 分钟宽限期
- `server.py`: `upgrade_support` 改为 `req.get()` 避免 KeyError
- `player_info.py`: 新增 `building_training` 字段
- `skill_upgrade`: 执行时间增加 null 检查 + 25h 边界校验
- `except: pass` 改为 `logger.warning`（3 处）

## 影响范围
- 全自动专精：核心改动
- 一键专精：共享执行路径，受益于所有训练室保护层
- 普通排班：仅在专精计划与基建排班表冲突时介入

## 测试验证

**未经过完整功能测试。** 改动涉及训练室操作、自动调度、重启恢复
等多个路径，建议至少在测试环境下完成以下验证：

1. 全自动专精 M1 → M2 → M3 完整流程（含协助干员级联换人）
2. 专精进行中重启后的自动恢复
3. 专精进行中手动触发仓库扫描 / 基建排班 / 心情纠错
4. 专精计划与基建排班表冲突时的报错
5. 前端训练路线编辑、保存、加载、恢复默认
6. 材料不足场景（确认不阻塞正常排班）
7. supports 为空时的邮件告警