### PR TITLE
feat: 重构全自动专精调度、增加加工站干员配置并修复邮件和无法删除的加工配置问题

### DIFF
--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -130,6 +130,9 @@ def simulate(saved):
             base_scheduler.op_data.skill_upgrade_supports = saved[
                 "skill_upgrade_supports"
             ]
+            base_scheduler._completed_masteries = saved.get(
+                "_completed_masteries", set()
+            )
             base_scheduler.tasks = tasks
             if len(base_scheduler.op_data.backup_plans) > 0:
                 # 启动的时候按照条件触发副表
@@ -210,6 +213,21 @@ def simulate(saved):
                             logger.info(
                                 f"仓库扫描未到时间，将在 {config.conf.maa_gap - dt // 3600}小时之内开始扫描"
                             )
+
+                    skip_routine = False
+                    from arknights_mower.utils.scheduler_task import (
+                        TaskTypes as _TaskTypes,
+                    )
+
+                    next_upgrade = base_scheduler.find_next_task(
+                        task_type=_TaskTypes.SKILL_UPGRADE
+                    )
+                    if next_upgrade is not None and next_upgrade.time <= datetime.now():
+                        logger.info("仓库扫描后有专精任务待执行，立即运行后继续日常")
+                        base_scheduler.run()
+                        from arknights_mower.utils.scheduler_task import scheduling
+
+                        scheduling(base_scheduler.tasks)
                     if config.conf.maa_enable != 1:
                         base_scheduler.mower_plan_solver()
                     elif config.conf.maa_enable == 1:
@@ -319,6 +337,7 @@ def simulate(saved):
                     base_scheduler.sleeping = False
                     base_scheduler.check_current_focus()
 
+            base_scheduler._training_sm.gate_sync()
             base_scheduler.run()
             reconnect_tries = 0
         except MowerExit:

--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -46,6 +46,7 @@ from arknights_mower.solvers.report import ReportSolver
 from arknights_mower.solvers.secret_front import SecretFront
 from arknights_mower.solvers.shop import CreditShop
 from arknights_mower.solvers.skland import SKLand
+from arknights_mower.solvers.training_state import TrainingState
 from arknights_mower.utils import config, detector, rapidocr
 from arknights_mower.utils import typealias as tp
 from arknights_mower.utils.csleep import MowerExit, csleep
@@ -120,6 +121,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         self.drop_send = False
         self.global_plan = {}
         self.local_operation_followup_time = None
+        from arknights_mower.solvers.training_state import TrainingStateMachine
+
+        self._training_sm = TrainingStateMachine(self)
+        self._completed_masteries = set()
+        self._m3_cache_mtime = 0
+        self._m3_cache_set = set()
+        self._training_completion_time = None
 
     def find_next_task(
         self,
@@ -168,6 +176,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             self.task = self.tasks[0]
         else:
             self.task = None
+        if self._training_sm.state == TrainingState.TRAINING and self.task is not None:
+            if (self.task.time - datetime.now()).total_seconds() > 300:
+                self.task = None
         if self.task is not None and datetime.now() < self.task.time:
             reschedule_time = (self.task.time - datetime.now()).total_seconds()
             if reschedule_time > 0:
@@ -238,7 +249,11 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 )
                 self.tasks.append(task)
         else:
-            msg = f"无法完成 {self.task.meta_data} 的排班，如果重复接收此邮件请检查替换组是否被占用"
+            ctx = self._training_sm.get_training_context()
+            if ctx:
+                msg = f"{ctx['name']} 技能{ctx['skill_label']} 专精{ctx['level']} 的协助位排班失败，请检查替换组是否被占用"
+            else:
+                msg = f"无法完成 {self.task.meta_data} 的排班，如果重复接收此邮件请检查替换组是否被占用"
             send_message(msg, level="ERROR")
             logger.error(msg)
             # 简单暴力一点，移除所有非回满的
@@ -295,7 +310,11 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 ):
                     break
             if current_resting - len(remove_name) + required > len(self.op_data.dorm):
-                msg = f"无法完成 {self.task.meta_data} 的排班，宿舍可用空位不足，请减少使用回满词条"
+                ctx = self._training_sm.get_training_context()
+                if ctx:
+                    msg = f"{ctx['name']} 技能{ctx['skill_label']} 专精{ctx['level']} 的协助位排班失败，宿舍可用空位不足"
+                else:
+                    msg = f"无法完成 {self.task.meta_data} 的排班，宿舍可用空位不足，请减少使用回满词条"
                 send_message(msg, level="ERROR")
                 return
             logger.debug(f"需要提前移出宿舍的干员: {remove_name}")
@@ -323,7 +342,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     )
                 )
             else:
-                msg = f"无法完成 {self.task.meta_data} 的排班，请检查是否有替换组冲突"
+                ctx = self._training_sm.get_training_context()
+                if ctx:
+                    msg = f"{ctx['name']} 技能{ctx['skill_label']} 专精{ctx['level']} 的协助位排班失败，请检查是否有替换组冲突"
+                else:
+                    msg = (
+                        f"无法完成 {self.task.meta_data} 的排班，请检查是否有替换组冲突"
+                    )
                 logger.warning(msg)
                 send_message(msg, level="ERROR")
             self.skip()
@@ -490,7 +515,10 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             return
         if self.task is not None:
             try:
-                if len(self.task.plan.keys()) > 0:
+                if self.task.type == TaskTypes.SKILL_UPGRADE:
+                    self._training_sm.sync()
+                    self.skill_upgrade(self.task.meta_data)
+                elif len(self.task.plan.keys()) > 0:
                     get_time = False
                     if TaskTypes.SHIFT_OFF == self.task.type:
                         get_time = True
@@ -594,11 +622,33 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                             task_type=TaskTypes.SKILL_UPGRADE
                         ):
                             self.refresh_skill_time(upgrade)
+                            self._training_completion_time = upgrade.time
+                            try:
+                                level = self._training_sm.get_training_level()
+                                support = next(
+                                    (
+                                        e
+                                        for e in self.op_data.skill_upgrade_supports
+                                        if e.level == level
+                                    ),
+                                    None,
+                                )
+                                if (
+                                    support
+                                    and not config.conf.assistant_follows_schedule
+                                ):
+                                    self._schedule_half_off_swap_internal(
+                                        support,
+                                        self._training_completion_time,
+                                        upgrade.meta_data,
+                                    )
+                            except Exception:
+                                pass
                     else:
                         self.plan_run_order(self.task.meta_data)
                     self.skip(["todo_task", "collect_notification"])
-                elif self.task.type == TaskTypes.SKILL_UPGRADE:
-                    self.skill_upgrade(self.task.meta_data)
+                elif self.task.type == TaskTypes.NOT_SPECIFIC:
+                    pass
                 del self.tasks[0]
                 if self.tasks and self.tasks[0].type in [TaskTypes.SHIFT_ON]:
                     self.backup_plan_solver(PlanTriggerTiming.AFTER_PLANNING)
@@ -904,12 +954,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                                 or self.op_data.operators[x].is_resting()
                             ):
                                 room = self.op_data.operators[x].room
-                                if room == "train" and (
-                                    self.find_next_task(
-                                        task_type=TaskTypes.SKILL_UPGRADE
-                                    )
-                                    or self._is_mastery_context()
-                                ):
+                                if room == "train":
                                     continue
                                 if room not in fix_plan:
                                     fix_plan[room] = ["Current"] * len(plan[room])
@@ -933,8 +978,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     self.skip()
                     return
                 else:
-                    if self._is_mastery_context():
-                        fix_plan.pop("train", None)
+                    fix_plan.pop("train", None)
                     self.tasks.append(
                         SchedulerTask(
                             task_plan=fix_plan, task_type=TaskTypes.SELF_CORRECTION
@@ -963,13 +1007,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 if scene == Scene.INFRA_MAIN:
                     self.enter_room("train")
                 if scene == Scene.TRAIN_MAIN:
-                    task.time = self.double_read_time(
-                        (
-                            (236, 978),
-                            (380, 1020),
-                        ),
-                        use_digit_reader=True,
-                    )
+                    task.time = self.double_read_time(((236, 978), (380, 1020)))
                     del tasks[0]
                 if scene == Scene.TRAIN_SKILL_SELECT:
                     self.back()
@@ -1246,6 +1284,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
 
     def skill_upgrade(self, skill):
         try:
+            if "|" in skill:
+                skill = skill.split("|")[0]
+            elif not skill.isdigit():
+                import re
+
+                m = re.search(r"技能(\d+)", skill)
+                if m:
+                    skill = m.group(1)
             unknown_cnt = 0
             tasks = ["collect", "upgrade", "confirm"]
             execute_time = None
@@ -1276,11 +1322,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         else:
                             logger.info("检测到专精未完成,刷新任务时间")
                             execute_time = self.double_read_time(
-                                (
-                                    (236, 978),
-                                    (380, 1020),
-                                ),
-                                use_digit_reader=True,
+                                ((236, 978), (380, 1020))
                             )
                             if (
                                 execute_time is not None
@@ -1292,6 +1334,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                                         time=execute_time,
                                         task_type=TaskTypes.SKILL_UPGRADE,
                                         meta_data=skill,
+                                        task_plan=self.task.plan,
                                         adjusted=True,
                                     )
                                 )
@@ -1306,37 +1349,42 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         )
                     if tasks[0] == "confirm":
                         # 读取专精倒计时 如果没有，判定专精失败
-                        execute_time = self.double_read_time(
-                            ((236, 978), (380, 1020)), use_digit_reader=True
-                        )
+                        execute_time = self.double_read_time(((236, 978), (380, 1020)))
                         if execute_time < (datetime.now() + timedelta(hours=2)):
                             raise Exception(
                                 "未获取专精时间倒计时，请确认技能专精材料充足"
                             )
                         else:
+                            self._training_completion_time = execute_time
                             del tasks[0]
                 elif scene == Scene.TRAIN_SKILL_SELECT:
                     if tasks[0] == "upgrade":
-                        # 点击技能
-                        height = (int(skill) - 1) * 0.3 + 0.32
-                        self.ctap((self.recog.w * 0.33, self.recog.h * height))
+                        skill_idx = int(skill) - 1
+                        lit_zones = self._training_sm.read_mastery_zones(skill_idx)
+                        pk = getattr(self.task, "plan_key", "")
+                        self._training_sm.set_trainee_info(lit_zones, pk)
+                        if lit_zones >= 3:
+                            logger.info(
+                                f"专精技能{skill}已满级（M3完成），lit_zones={lit_zones}"
+                            )
+                            plan_key = getattr(self.task, "plan_key", "")
+                            if plan_key:
+                                self._completed_masteries.add(plan_key)
+                                logger.info(f"记录已完成专精: {plan_key}")
+                            self.back()
+                            self._schedule_next_from_plan()
+                            return
+                        self.ctap(
+                            (
+                                self.recog.w * 0.33,
+                                self.recog.h * (skill_idx * 0.3 + 0.32),
+                            )
+                        )
                     else:
                         self.back()
                 elif scene == Scene.TRAIN_SKILL_UPGRADE:
                     if tasks[0] == "upgrade":
-                        # 根据剩余时间判定专精技能等级
-                        finish_time = self.double_read_time(
-                            (
-                                (94, 998),
-                                (223, 1048),
-                            ),
-                            use_digit_reader=True,
-                        )
-                        hours = (finish_time - datetime.now()).total_seconds() / 3600
-                        if hours > 23:
-                            level = 3
-                        elif hours > 15:
-                            level = 2
+                        level = self._training_sm.get_training_level()
                         logger.info(f"本次专精将提升{skill}技能至{level}")
                         # 点击确认开始专精
                         self.tap((self.recog.w * 0.87, self.recog.h * 0.9))
@@ -1346,11 +1394,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 elif scene == Scene.TRAIN_SKILL_UPGRADE_ERROR:
                     # 如果材料不满足则会出现错误
                     if tasks[0] == "confirm":
-                        logger.warning("专精材料不足，将在下次仓库扫描时自动重试")
-                        send_message(
-                            "专精材料不足，将在下次仓库扫描时自动重试",
-                            level="ERROR",
-                        )
+                        level = self._training_sm.get_training_level()
+                        ctx = self._training_sm.get_training_context()
+                        if ctx:
+                            msg = f"{ctx['name']} 技能{ctx['skill_label']} 专精{level} 材料不足，将在下次仓库扫描时自动重试"
+                        else:
+                            msg = "专精材料不足，将在下次仓库扫描时自动重试"
+                        logger.warning(msg)
+                        send_message(msg, level="ERROR")
                         self.back()
                         return
                     else:
@@ -1364,8 +1415,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     ),
                     None,
                 )
-                h = self.op_data.calculate_switch_time(support)
-                if support is not None:
+                if support is not None and not config.conf.assistant_follows_schedule:
                     self.tasks.append(
                         SchedulerTask(
                             task_plan={"train": [support.name, "Current"]},
@@ -1373,47 +1423,18 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                             adjusted=True,
                         )
                     )
-                    # 提前10分钟换人，确保触发技能
-                    # 3 级不需要换人
-                    if level != 3:
-                        swap_time = (
-                            datetime.now() + timedelta(hours=h) - timedelta(minutes=10)
-                        )
-                        self.tasks.append(
-                            SchedulerTask(
-                                time=swap_time,
-                                task_plan={"train": [support.swap_name, "Current"]},
-                                meta_data="_mastery",
-                                adjusted=True,
-                            )
-                        )
-                        self.tasks.append(
-                            SchedulerTask(
-                                time=swap_time + timedelta(seconds=1),
-                                task_plan={},
-                                task_type=TaskTypes.REFRESH_TIME,
-                                meta_data="train",
-                            )
-                        )
-                        # 默认 5小时
-                        self.tasks.append(
-                            SchedulerTask(
-                                time=datetime.now()
-                                + timedelta(hours=h + 5)
-                                + timedelta(minutes=15),
-                                task_plan={},
-                                task_type=TaskTypes.SKILL_UPGRADE,
-                                meta_data=skill,
-                            )
-                        )
-                else:
                     self.tasks.append(
                         SchedulerTask(
-                            time=execute_time,
+                            time=datetime.now() + timedelta(seconds=5),
                             task_plan={},
-                            task_type=TaskTypes.SKILL_UPGRADE,
-                            meta_data=skill,
+                            task_type=TaskTypes.REFRESH_TIME,
+                            meta_data="train",
                         )
+                    )
+                else:
+                    raise Exception(
+                        f"专精路线中未找到等级 {level} 的协助位干员配置，"
+                        "请检查并完善专精路线"
                     )
             else:
                 raise Exception(
@@ -1423,7 +1444,103 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             self.back()
         except Exception as e:
             logger.exception(e)
-            send_message("专精任务失败" + str(e), level="ERROR")
+            ctx = self._training_sm.get_training_context()
+            if ctx:
+                msg = f"{ctx['name']} 技能{ctx['skill_label']} 专精{ctx['level']} 任务失败: {e}"
+            else:
+                msg = f"专精任务失败: {e}"
+            send_message(msg, level="ERROR")
+
+    def _schedule_half_off_swap_internal(
+        self, support, completion_time, skill_label, check_duplicate=False
+    ):
+        central_bonus = 0
+        try:
+            import json as _json
+
+            route_path = get_path("@app/tmp/matery_route.json")
+            if os.path.exists(route_path):
+                with open(route_path, "r", encoding="utf-8") as _f:
+                    _route = _json.load(_f)
+                if _route.get("controlCenter", "none") != "none":
+                    central_bonus = 5
+        except Exception:
+            pass
+        basic = 5
+        match_bonus = 30 if support.match else 0
+        ratio = (100 + basic + central_bonus + match_bonus) / (
+            100 + support.efficiency + basic + central_bonus
+        )
+        need_real_h = 5 * ratio
+        remaining_h = (completion_time - datetime.now()).total_seconds() / 3600
+        if remaining_h <= need_real_h + 10 / 60:
+            logger.warning(
+                f"减半需求{need_real_h + 10 / 60:.2f}h > "
+                f"剩余{remaining_h:.2f}h，跳过换人"
+            )
+            return
+        swap_time = (
+            completion_time - timedelta(hours=need_real_h) - timedelta(minutes=10)
+        )
+        if swap_time <= datetime.now():
+            swap_time = datetime.now()
+        if check_duplicate:
+            has_swap = any(
+                getattr(t, "meta_data", None) == "_mastery"
+                and isinstance(getattr(t, "plan", None), dict)
+                and getattr(t, "plan", {}).get("train", [None])[0] == support.swap_name
+                for t in self.tasks
+            )
+            if has_swap:
+                logger.debug(f"减半换人: 换人任务 {support.swap_name} already in queue")
+                return
+        logger.info(f"减半换人: {swap_time.strftime('%H:%M')} 换上 {support.swap_name}")
+        self.tasks.append(
+            SchedulerTask(
+                time=swap_time,
+                task_plan={"train": [support.swap_name, "Current"]},
+                meta_data="_mastery",
+                adjusted=True,
+            )
+        )
+        self.tasks.append(
+            SchedulerTask(
+                time=swap_time + timedelta(seconds=1),
+                task_plan={},
+                task_type=TaskTypes.REFRESH_TIME,
+                meta_data="train",
+            )
+        )
+        enriched = skill_label
+        try:
+            cid = self._training_sm._trainee_cid
+            if cid:
+                from arknights_mower.utils.mastery_recommendation import get_skill_data
+
+                char_table = get_skill_data().get("characters", {})
+                name = char_table.get(cid, {}).get("name", "")
+                if name:
+                    lvl = self._training_sm._lit_zones + 1
+                    enriched = f"{name} 技能{skill_label} -> 专精{lvl} "
+        except Exception:
+            pass
+        self.tasks.append(
+            SchedulerTask(
+                time=completion_time + timedelta(minutes=15),
+                task_plan={},
+                task_type=TaskTypes.SKILL_UPGRADE,
+                meta_data=enriched,
+            )
+        )
+
+    def _schedule_half_off_swap(self, support, level, skill):
+        if level == 3 or self._training_completion_time is None:
+            return
+        self._schedule_half_off_swap_internal(
+            support,
+            self._training_completion_time,
+            skill,
+        )
 
     def plan_run_order(self, room):
         plan = self.op_data.plan
@@ -1658,60 +1775,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         # return adjust_0_room , adjust_0_room_len
         return adjust_0_room
 
-    def _check_mastery_plan_conflict(self):
-        conflicts = []
-        mastering = set()
-
-        plan = self._get_mastery_plan()
-        if plan:
-            try:
-                planned_ids = {k.split("_")[0] for k, v in plan.items() if v}
-                if planned_ids:
-                    from arknights_mower.utils.mastery_recommendation import (
-                        get_skill_data,
-                    )
-
-                    char_table = get_skill_data().get("characters", {})
-                    for cid in planned_ids:
-                        info = char_table.get(cid)
-                        if info:
-                            mastering.add(info.get("name", cid))
-            except Exception:
-                pass
-
-        for t in self.tasks:
-            if t.type == TaskTypes.SHIFT_ON:
-                for room, agents in t.plan.items():
-                    if "train" in room and len(agents) > 1 and agents[1] != "Current":
-                        mastering.add(agents[1])
-
-        if not mastering:
-            return []
-
-        for key in self.op_data.plan:
-            if "train" in key:
-                continue
-            for name in self.op_data.plan[key]:
-                if hasattr(name, "agent"):
-                    name = name.agent
-                if name in mastering:
-                    conflicts.append((name, key))
-
-        return conflicts
-
     def plan_solver(self):
-        conflicts = self._check_mastery_plan_conflict()
-        if conflicts:
-            msgs = [
-                f"{n} 在排班表 {r} 中，同时存在于专精计划/任务" for n, r in conflicts
-            ]
-            for m in msgs:
-                logger.error(m)
-            raise Exception(
-                f"检测到 {len(conflicts)} 个专精与排班冲突，请手动调整："
-                + "; ".join(f"{n}→{r}" for n, r in conflicts)
-            )
-
         # 准备数据
         logger.debug(self.op_data.print())
         # 根据剩余心情排序
@@ -1749,6 +1813,22 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             try_workshop_tasks(self.op_data, self.tasks)
         if not self.find_next_task(datetime.now() + timedelta(minutes=5)):
             try_add_release_dorm({}, None, self.op_data, self.tasks)
+        if self._get_mastery_plan() and not self.find_next_task(
+            task_type=TaskTypes.SKILL_UPGRADE
+        ):
+            sk = str(
+                self._training_sm._target_skill + 1
+                if self._training_sm._target_skill >= 0
+                else "1"
+            )
+            self.tasks.append(
+                SchedulerTask(
+                    time=datetime.now(),
+                    task_type=TaskTypes.SKILL_UPGRADE,
+                    meta_data=sk,
+                    adjusted=True,
+                )
+            )
         if self.find_next_task(datetime.now() + timedelta(seconds=15)):
             logger.info("有其他任务,跳过宿舍纠错")
             return
@@ -2736,6 +2816,12 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     logger.info(f"需要选择的干员：{select_targets}")
                     idx = select_targets[0][0]
                     if idx == 0:
+                        if agents[idx] == "Free":
+                            select_targets.pop(0)
+                            if select_targets:
+                                continue
+                            tasks[0] = "scan"
+                            continue
                         self.choose_agent([agents[idx]], "train", fast_mode)
                     else:
                         self.choose_train_ope(agents[idx])
@@ -3369,6 +3455,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             try:
                 error_count = 0
                 if not skip_enter:
+                    if room == "train" and self._training_sm.should_skip_room(
+                        self.task
+                    ):
+                        if config.conf.assistant_follows_schedule:
+                            pass
+                        else:
+                            del plan[room]
+                            return new_plan
                     self.enter_room(room)
                 self.turn_on_room_detail(room)
                 error_count = 0
@@ -3448,11 +3542,16 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                             self.reset_room_time(room)
                             raise Exception("检测到漏单！")
                     if room == "train":
-                        if self._should_skip_train_room(self.task):
-                            self.get_agent_from_room("train")
-                            del plan[room]
-                            return new_plan
-                        self.choose_train(plan[room], choose_error <= 0)
+                        if (
+                            config.conf.assistant_follows_schedule
+                            and self._training_sm.state != TrainingState.IDLE
+                            and len(plan[room]) > 1
+                        ):
+                            train_plan = list(plan[room])
+                            train_plan[1] = "Current"
+                            self.choose_train(train_plan, choose_error <= 0)
+                        else:
+                            self.choose_train(plan[room], choose_error <= 0)
                     else:
                         while self.find("confirm_blue") is None:
                             if error_count > 3:
@@ -3534,40 +3633,33 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
 
     def _get_mastery_plan(self):
         plan_path = get_path("@app/tmp/matery_plan.json")
-        if os.path.exists(plan_path):
-            try:
-                with open(plan_path, "r", encoding="utf-8") as f:
-                    return json.load(f)
-            except Exception:
-                return {}
-        return {}
-
-    def _is_mastery_context(self):
-        if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
-            return True
+        if not os.path.exists(plan_path):
+            return {}
         try:
-            from arknights_mower.solvers.player_info import player_info_cache
-
-            latest = player_info_cache.get("latest", {})
-            training = (
-                latest.get("building_training") if isinstance(latest, dict) else None
-            )
-            if training is not None:
-                return isinstance(training.get("trainee"), dict)
+            with open(plan_path, "r", encoding="utf-8") as f:
+                plan = json.load(f)
+        except Exception:
+            return {}
+        if not plan:
+            return {}
+        try:
+            cultivate_path = get_path("@app/tmp/cultivate.json")
+            if os.path.exists(cultivate_path):
+                mtime = os.path.getmtime(cultivate_path)
+                if mtime != self._m3_cache_mtime:
+                    with open(cultivate_path, "r", encoding="utf-8") as f:
+                        cdata = json.load(f)
+                    m3 = set()
+                    for char in cdata.get("data", {}).get("characters", []):
+                        for idx, s in enumerate(char.get("skills", [])):
+                            if s.get("level", 0) >= 3:
+                                m3.add(f"{char.get('id')}_{idx}")
+                    self._m3_cache_mtime = mtime
+                    self._m3_cache_set = m3
+                plan = {k: v for k, v in plan.items() if k not in self._m3_cache_set}
         except Exception:
             pass
-        return False
-
-    def _should_skip_train_room(self, task):
-        if task.meta_data == "_mastery":
-            return False
-        if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
-            logger.info("有未完成的专精任务，跳过训练室排班")
-            return True
-        if self._is_mastery_context():
-            logger.info("训练室专精进行中，跳过非专精排班")
-            return True
-        return False
+        return plan
 
     def agent_arrange(self, plan: tp.BasePlan, get_time=False):
         logger.info("基建：排班")
@@ -4615,12 +4707,6 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     def 仓库扫描(self):
         try:
             cultivateDepotSolver().start()
-            try:
-                from arknights_mower.solvers.player_info import PlayerInfoClient
-
-                PlayerInfoClient().get_first_available_snapshot()
-            except Exception:
-                pass
             DepotSolver(self.device, self.recog).run()
             self._auto_schedule_mastery_after_scan()
         except Exception as e:
@@ -4629,105 +4715,110 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             return False
         return True
 
-    def _verify_and_recover_mastery_room(self):
-        """用 SKLand 训练室数据验证、纠错并恢复丢失的专精任务"""
+    def _schedule_next_from_plan(self):
         try:
-            from arknights_mower.solvers.player_info import player_info_cache
             from arknights_mower.utils.mastery_recommendation import (
-                _build_route_supports,
-                get_skill_data,
+                auto_schedule_mastery_tasks,
             )
             from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
 
-            latest = player_info_cache.get("latest", {})
-            training = (
-                latest.get("building_training") if isinstance(latest, dict) else None
-            )
-            if not training:
-                return
-
-            trainee = training.get("trainee")
-            trainer = training.get("trainer")
-
-            if not isinstance(trainee, dict):
-                return
-
-            if training.get("remainSecs", 0) <= 0:
-                return
-
-            trainee_cid = trainee.get("charId")
-            target_skill = trainee.get("targetSkill")
-            if not trainee_cid or target_skill is None:
-                return
-
-            char_table = get_skill_data().get("characters", {})
-            trainee_name = char_table.get(trainee_cid, {}).get("name", trainee_cid)
-            trainee_skill_label = str(target_skill + 1)
-
-            plan_has_trainee = False
-            matery_plan = self._get_mastery_plan()
-            if matery_plan:
-                try:
-                    plan_key = f"{trainee_cid}_{target_skill}"
-                    if matery_plan.get(plan_key):
-                        plan_has_trainee = True
-                except Exception:
-                    pass
-
-            supports_list = self.op_data.skill_upgrade_supports
-            if not supports_list and matery_plan:
-                try:
-                    trainee_info = char_table.get(trainee_cid, {})
-                    profession = trainee_info.get("profession", "")
-                    if profession:
+            res = auto_schedule_mastery_tasks()
+            for entry in res.get("scheduled", []):
+                plan_key = f"{entry['char_id']}_{entry['skill_index']}"
+                if plan_key in self._completed_masteries:
+                    logger.info(
+                        f"跳过已完成专精（黑名单）: {entry['name']} {entry['skill_name']}"
+                    )
+                    continue
+                sk = str(entry["skill_index"] + 1)
+                if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+                    logger.info(
+                        f"训练室已有专精任务，跳过 {entry['name']} {entry['skill_name']}"
+                    )
+                    continue
+                if not self.op_data.skill_upgrade_supports:
+                    try:
                         from arknights_mower.utils.mastery_recommendation import (
+                            _build_route_supports,
                             _supports_from_dicts,
                         )
 
-                        route = _build_route_supports(profession)
-                        if route:
-                            supports_list = _supports_from_dicts(route)
-                except Exception as e:
-                    logger.warning(f"恢复时加载专精路线失败: {e}")
-
-            if trainer and isinstance(trainer, dict) and supports_list:
-                trainer_cid = trainer.get("charId")
-                trainer_name = (
-                    char_table.get(trainer_cid, {}).get("name", trainer_cid)
-                    if trainer_cid
-                    else ""
+                        supports = _supports_from_dicts(
+                            _build_route_supports(entry["profession"])
+                        )
+                        self.op_data.skill_upgrade_supports = supports
+                    except Exception as e:
+                        logger.warning(f"加载专精路线失败: {e}")
+                first_support = ""
+                if self.op_data.skill_upgrade_supports:
+                    first_support = self.op_data.skill_upgrade_supports[0].name
+                assistant = (
+                    "Free" if config.conf.assistant_follows_schedule else first_support
                 )
-                support_names = {s.name for s in supports_list}
-                if trainer_name and trainer_name not in support_names:
-                    logger.warning(
-                        f"协助位干员 {trainer_name} 不在支持列表中，下次换人会纠正"
+                if assistant:
+                    self.tasks.append(
+                        SchedulerTask(
+                            task_plan={"train": [assistant, entry["name"]]},
+                            meta_data="_mastery",
+                        )
                     )
-
-            if not plan_has_trainee and not self.find_next_task(meta_data="_mastery"):
-                logger.error(
-                    f"训练位干员 {trainee_name} skill_{trainee_skill_label}"
-                    f" 不在专精计划和一键专精上下文中"
-                )
-                return
-
-            sk = trainee_skill_label
-            if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE, meta_data=sk):
-                return
-
-            logger.info(
-                f"从森空岛恢复专精任务: {trainee_name} skill_{sk}"
-                f" (charId={trainee_cid}, targetSkill={target_skill})"
-            )
-            self.tasks.append(
-                SchedulerTask(
-                    time=datetime.now(),
+                target_lvl = entry.get("current_level", 0) + 1
+                t = SchedulerTask(
                     task_type=TaskTypes.SKILL_UPGRADE,
-                    meta_data=sk,
+                    meta_data=f"{entry['name']} 技能{sk} -> 专精{target_lvl} ",
                     adjusted=True,
                 )
-            )
-        except Exception:
-            pass
+                t.plan_key = plan_key
+                self.tasks.append(t)
+                logger.info(
+                    f"M3完成后自动安排专精: {entry['name']} {entry['skill_name']}"
+                )
+                break
+            skipped = res.get("skipped", [])
+            if skipped:
+                names = [f"{s['name']}{s['skill_name']}" for s in skipped]
+                logger.info(f"跳过专精（材料不足）: {', '.join(names)}")
+        except Exception as e:
+            logger.exception(f"M3完成后自动排专精失败: {e}")
+
+    def _clean_completed_masteries(self):
+        import json
+        import os
+
+        from arknights_mower.utils.path import get_path
+
+        if not self._completed_masteries:
+            return
+        try:
+            cultivate_path = get_path("@app/tmp/cultivate.json")
+            if not os.path.exists(cultivate_path):
+                return
+            with open(cultivate_path, "r", encoding="utf-8") as f:
+                cdata = json.load(f)
+            char_levels = {}
+            for char in cdata.get("data", {}).get("characters", []):
+                cid = char.get("id")
+                skills = char.get("skills", [])
+                char_levels[cid] = {i: s.get("level", 0) for i, s in enumerate(skills)}
+            cleaned = set()
+            for plan_key in self._completed_masteries:
+                parts = plan_key.rsplit("_", 1)
+                if len(parts) != 2:
+                    continue
+                cid = parts[0]
+                try:
+                    skill_idx = int(parts[1])
+                except ValueError:
+                    continue
+                level = char_levels.get(cid, {}).get(skill_idx, 0)
+                if level >= 3:
+                    cleaned.add(plan_key)
+                    logger.info(
+                        f"清理已完成专精黑名单: {plan_key} (cultivate level={level})"
+                    )
+            self._completed_masteries -= cleaned
+        except Exception as e:
+            logger.warning(f"清理已完成专精黑名单失败: {e}")
 
     def _auto_schedule_mastery_after_scan(self):
         try:
@@ -4738,14 +4829,31 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
 
             res = auto_schedule_mastery_tasks()
-            self._verify_and_recover_mastery_room()
+            if res.get("scheduled"):
+                self._training_sm.sync()
+            logger.debug(
+                "仓库扫描: 专精调度完毕, "
+                f"scheduled={len(res.get('scheduled', []))}, "
+                f"skipped={len(res.get('skipped', []))}"
+            )
             for entry in res.get("scheduled", []):
+                plan_key = f"{entry['char_id']}_{entry['skill_index']}"
+                if plan_key in self._completed_masteries:
+                    logger.info(
+                        f"跳过已完成专精（黑名单）: {entry['name']} {entry['skill_name']}"
+                    )
+                    continue
                 sk = str(entry["skill_index"] + 1)
                 has = self.find_next_task(
                     task_type=TaskTypes.SKILL_UPGRADE,
                     meta_data=sk,
                 )
                 if not has:
+                    if self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+                        logger.info(
+                            f"训练室已有专精任务，跳过 {entry['name']} {entry['skill_name']}"
+                        )
+                        continue
                     if not self.op_data.skill_upgrade_supports:
                         try:
                             from arknights_mower.utils.mastery_recommendation import (
@@ -4762,10 +4870,15 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     first_support = ""
                     if self.op_data.skill_upgrade_supports:
                         first_support = self.op_data.skill_upgrade_supports[0].name
-                    if first_support:
+                    assistant = (
+                        "Free"
+                        if config.conf.assistant_follows_schedule
+                        else first_support
+                    )
+                    if assistant:
                         self.tasks.append(
                             SchedulerTask(
-                                task_plan={"train": [first_support, entry["name"]]},
+                                task_plan={"train": [assistant, entry["name"]]},
                                 meta_data="_mastery",
                             )
                         )
@@ -4773,20 +4886,27 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         logger.warning(
                             f"无法为 {entry['name']} 生成训练室换人任务，支持列表为空"
                         )
-                    self.tasks.append(
-                        SchedulerTask(
-                            task_type=TaskTypes.SKILL_UPGRADE,
-                            meta_data=sk,
-                            adjusted=True,
-                        )
+                    target_lvl = entry.get("current_level", 0) + 1
+                    t = SchedulerTask(
+                        task_type=TaskTypes.SKILL_UPGRADE,
+                        meta_data=f"{entry['name']} 技能{sk} -> 专精{target_lvl} ",
+                        adjusted=True,
                     )
+                    t.plan_key = plan_key
+                    self.tasks.append(t)
                     logger.info(f"自动安排专精: {entry['name']} {entry['skill_name']}")
             skipped = res.get("skipped", [])
             if skipped:
                 names = [f"{s['name']}{s['skill_name']}" for s in skipped]
                 logger.info(f"跳过专精（材料不足）: {', '.join(names)}")
 
-            new_settings = compute_workshop_config()
+            self._clean_completed_masteries()
+
+            new_settings = compute_workshop_config(
+                fodder_operators=config.conf.fodder_operators,
+                t5_operators=config.conf.t5_operators,
+                book_operators=config.conf.book_operators,
+            )
             if new_settings is not None:
                 from arknights_mower.utils.config.conf import (
                     RIICPart,

--- a/arknights_mower/solvers/record.py
+++ b/arknights_mower/solvers/record.py
@@ -96,6 +96,7 @@ def save_state(func):
             "daily_mail": base_scheduler.daily_mail,
             "task_count": base_scheduler.task_count,
             "skill_upgrade_supports": base_scheduler.op_data.skill_upgrade_supports,
+            "_completed_masteries": base_scheduler._completed_masteries,
         }
 
         # Call the original function

--- a/arknights_mower/solvers/report.py
+++ b/arknights_mower/solvers/report.py
@@ -103,7 +103,7 @@ class ReportSolver(SceneGraphSolver):
                     if k == "龙舌兰":
                         key = "龙舌兰" + "(2500)"
                         value = 2500 * count
-                    if k == "可露希尔":
+                    elif k == "可露希尔":
                         key = "可露希尔" + "(1200)"
                         value = 1200 * count
                     else:

--- a/arknights_mower/solvers/training_state.py
+++ b/arknights_mower/solvers/training_state.py
@@ -1,0 +1,615 @@
+import json
+import os
+from datetime import datetime, timedelta
+from enum import Enum
+
+from arknights_mower.utils.log import logger
+from arknights_mower.utils.mastery_recommendation import (
+    _build_route_supports,
+    _supports_from_dicts,
+    get_skill_data,
+)
+from arknights_mower.utils.path import get_path
+from arknights_mower.utils.scene import Scene
+from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
+
+
+class TrainingState(Enum):
+    IDLE = 0
+    TRAINING = 1
+    WAITING_COLLECT = 2
+
+
+class TrainingStateMachine:
+    def __init__(self, scheduler):
+        self._scheduler = scheduler
+        self._state = TrainingState.IDLE
+        self._transition_history = []
+        self._transition_max_interval = 60
+        self._transition_max_count = 5
+        self._last_training_countdown = None
+        self._initial_checked = False
+        self._lit_zones = 0
+        self._trainee_plan_key = ""
+        self._trainee_name = ""
+        self._trainee_cid = ""
+        self._target_skill = -1
+        self._trainer_name = ""
+
+    def gate_sync(self):
+        plan = self._scheduler._get_mastery_plan()
+        if plan:
+            from arknights_mower.utils.scheduler_task import TaskTypes
+
+            if not self._scheduler.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+                self.sync()
+
+    @property
+    def state(self):
+        return self._state
+
+    def sync(self):
+        import traceback
+
+        caller = traceback.extract_stack()[-2].name
+        new_state = self._determine_state()
+        if new_state == self._state:
+            self._act_on_state(new_state)
+            return
+        old = self._state
+        self._state = new_state
+        self._transition_history.append((datetime.now(), old.name, new_state.name))
+        if len(self._transition_history) > self._transition_max_count:
+            self._transition_history.pop(0)
+        if (
+            len(self._transition_history) >= self._transition_max_count
+            and (
+                self._transition_history[-1][0] - self._transition_history[0][0]
+            ).total_seconds()
+            < self._transition_max_interval
+        ):
+            logger.warning(
+                f"STUCK_DETECT: {len(self._transition_history)} "
+                f"transitions in {self._transition_max_interval}s"
+            )
+            self._transition_history.clear()
+        logger.info(f"训练室状态: {old.name} -> {new_state.name} (来自{caller})")
+        if old == TrainingState.IDLE and new_state == TrainingState.TRAINING:
+            if self._trainee_name and self._target_skill >= 0:
+                lvl = self._lit_zones + 1
+                logger.info(
+                    f"恢复全自动专精任务：{self._trainee_name} "
+                    f"技能{self._target_skill + 1} -> 专精{lvl}"
+                )
+        if new_state == TrainingState.IDLE:
+            if self._scheduler.op_data.skill_upgrade_supports:
+                logger.info(
+                    f"训练室空闲: 已清除协助位配置 "
+                    f"(之前 {[s.name for s in self._scheduler.op_data.skill_upgrade_supports]})"
+                )
+            self._scheduler.op_data.skill_upgrade_supports = []
+            self._lit_zones = 0
+            self._trainee_plan_key = ""
+            self._trainee_name = ""
+            self._trainee_cid = ""
+            self._target_skill = -1
+            self._trainer_name = ""
+        self._act_on_state(new_state)
+
+    def _determine_state(self):
+        plan = self._scheduler._get_mastery_plan()
+        if not plan:
+            logger.debug("_determine_state: plan empty -> IDLE")
+            return TrainingState.IDLE
+        if self._state == TrainingState.IDLE and self._initial_checked:
+            logger.debug(
+                "_determine_state: IDLE (already checked), skip physical entry"
+            )
+            return TrainingState.IDLE
+        if (
+            self._state == TrainingState.TRAINING
+            and self._last_training_countdown is not None
+            and self._last_training_countdown > datetime.now()
+        ):
+            logger.debug(
+                "_determine_state: training still running "
+                "(countdown valid), cache state=TRAINING"
+            )
+            return TrainingState.TRAINING
+        self._initial_checked = True
+        result = self._read_physical_state()
+        logger.debug(f"_determine_state: plan non-empty, physical={result.name}")
+        return result
+
+    def should_skip_room(self, task):
+        if task.meta_data == "_mastery":
+            return False
+        if self._scheduler.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+            logger.info("有未完成的专精任务，跳过训练室排班")
+            return True
+        if self._state in {
+            TrainingState.TRAINING,
+            TrainingState.WAITING_COLLECT,
+        }:
+            logger.info("训练室专精进行中，跳过非专精排班")
+            return True
+        return False
+
+    def get_training_context(self):
+        """返回当前训练详情 {name, skill_label, level}，若无活跃训练则返回 None"""
+        try:
+            if self._lit_zones == 0 or not self._trainee_plan_key:
+                return None
+            from arknights_mower.utils.mastery_recommendation import get_skill_data
+
+            parts = self._trainee_plan_key.rsplit("_", 1)
+            if len(parts) != 2:
+                return None
+            char_table = get_skill_data().get("characters", {})
+            name = char_table.get(parts[0], {}).get("name", "")
+            if not name:
+                return None
+            training_lvl = self._lit_zones + 1
+            return {
+                "name": name,
+                "skill_label": str(training_lvl),
+                "level": training_lvl,
+            }
+        except Exception:
+            pass
+        return None
+
+    def set_trainee_info(self, lit_zones, plan_key):
+        self._lit_zones = lit_zones
+        self._trainee_plan_key = plan_key
+
+    def get_training_level(self):
+        return self._lit_zones + 1 if self._lit_zones > 0 else 1
+
+    def read_mastery_zones(self, skill_idx):
+        """在专精技能选择页面读取三角形区域的亮起数量 (0~3)"""
+        zone_coords = {
+            0: [  # 一技能
+                ((596, 167), (631, 202)),
+                ((575, 203), (610, 238)),
+                ((618, 203), (653, 238)),
+            ],
+            1: [  # 二技能
+                ((596, 483), (631, 518)),
+                ((575, 518), (610, 553)),
+                ((618, 518), (653, 553)),
+            ],
+            2: [  # 三技能
+                ((596, 799), (631, 834)),
+                ((575, 835), (610, 870)),
+                ((618, 835), (653, 870)),
+            ],
+        }
+        coords = zone_coords.get(skill_idx, [])
+        if not coords:
+            return 0
+        self._scheduler.recog.update()
+        gray = self._scheduler.recog.gray
+        lit = 0
+        threshold = 200
+        for (x0, y0), (x1, y1) in coords:
+            if y0 >= gray.shape[0] or x0 >= gray.shape[1]:
+                continue
+            y1 = min(y1, gray.shape[0])
+            x1 = min(x1, gray.shape[1])
+            crop = gray[y0:y1, x0:x1]
+            if crop.size == 0:
+                continue
+            bright_pixels = (crop > threshold).sum()
+            ratio = bright_pixels / crop.size
+            if ratio > 0.5:
+                lit += 1
+        logger.debug(f"read_mastery_zones(skill={skill_idx + 1}): lit={lit}/3")
+        return lit
+
+    def _enrich_meta(self, skill_label, cid, lvl):
+        """构建显示用的 meta_data"""
+        try:
+            char_table = get_skill_data().get("characters", {})
+            name = char_table.get(cid, {}).get("name", "")
+            if name:
+                return f"{name} 技能{skill_label} -> 专精{lvl} "
+        except Exception:
+            pass
+        return skill_label
+
+    def _read_physical_state(self):
+        self._scheduler.enter_room("train")
+        try:
+            scene = self._scheduler.train_scene()
+            if scene != Scene.TRAIN_MAIN:
+                self._last_training_countdown = None
+                return TrainingState.IDLE
+            # 先判断状态：检查是否可收集
+            completed_found = self._scheduler.find("training_completed")
+            if completed_found:
+                self._last_training_countdown = None
+                return TrainingState.WAITING_COLLECT
+            # 读倒计时确定是否在专精中
+            time_in_seconds = self._scheduler.read_time(
+                ((236, 978), (380, 1020)), upperlimit=None
+            )
+            if time_in_seconds is None:
+                self._last_training_countdown = None
+                return TrainingState.IDLE
+            execute_time = datetime.now() + timedelta(seconds=time_in_seconds)
+            self._last_training_countdown = execute_time
+            # 重试进入技能选择页（弹窗可能挡住，最多试 5 次）
+            skill_scene = Scene.UNKNOWN
+            for attempt in range(5):
+                self._scheduler.tap(
+                    (self._scheduler.recog.w * 0.05, self._scheduler.recog.h * 0.95),
+                )
+                self._scheduler.sleep(0.5)
+                skill_scene = self._scheduler.train_scene()
+                if skill_scene == Scene.TRAIN_SKILL_SELECT:
+                    break
+
+            if skill_scene == Scene.TRAIN_SKILL_SELECT:
+                try:
+                    for idx in range(3):
+                        self._scheduler.tap(
+                            (
+                                self._scheduler.recog.w * 0.33,
+                                self._scheduler.recog.h * (idx * 0.3 + 0.32),
+                            )
+                        )
+                    self._scheduler.sleep(0.1)
+                    self._scheduler.recog.update()
+                    gray = self._scheduler.recog.gray
+                    skill_regions = [
+                        ((792, 292), (909, 325)),
+                        ((792, 609), (909, 643)),
+                        ((792, 926), (909, 961)),
+                    ]
+                    means = []
+                    for (x0, y0), (x1, y1) in skill_regions:
+                        if y0 >= gray.shape[0] or x0 >= gray.shape[1]:
+                            means.append(255)
+                            continue
+                        y1 = min(y1, gray.shape[0])
+                        x1 = min(x1, gray.shape[1])
+                        crop = gray[y0:y1, x0:x1]
+                        means.append(crop.mean())
+                    self._target_skill = min(range(3), key=lambda i: means[i])
+                    self._lit_zones = self.read_mastery_zones(self._target_skill)
+                except Exception:
+                    pass
+                self._scheduler.back()
+            # 回到 TRAIN_MAIN 后读干员
+            current = self._scheduler.get_agent_from_room("train")
+            if not any(e["agent"] not in ("", "Free") for e in current):
+                self._last_training_countdown = None
+                return TrainingState.IDLE
+            if len(current) > 1:
+                self._trainer_name = current[0].get("agent", "")
+                self._trainee_name = current[1].get("agent", "")
+                char_table = get_skill_data().get("characters", {})
+                for cid, info in char_table.items():
+                    if info.get("name") == self._trainee_name:
+                        self._trainee_cid = cid
+                        break
+            return TrainingState.TRAINING
+        finally:
+            self._scheduler.back()
+
+    def _act_on_state(self, state):
+        if state == TrainingState.IDLE:
+            return
+        try:
+            if self._target_skill < 0 or not self._trainee_cid:
+                return
+
+            char_table = get_skill_data().get("characters", {})
+            trainee_name = self._trainee_name
+            trainee_cid = self._trainee_cid
+            target_skill = self._target_skill
+            trainee_skill_label = str(target_skill + 1)
+            trainer = {"charId": ""}
+            if self._trainer_name:
+                for cid, info in char_table.items():
+                    if info.get("name") == self._trainer_name:
+                        trainer["charId"] = cid
+                        break
+
+            plan_has_trainee = False
+            matery_plan = self._scheduler._get_mastery_plan()
+            if matery_plan:
+                try:
+                    plan_key = f"{trainee_cid}_{target_skill}"
+                    if matery_plan.get(plan_key):
+                        plan_has_trainee = True
+                except Exception:
+                    pass
+
+            supports_list = self._scheduler.op_data.skill_upgrade_supports
+            if not supports_list and matery_plan:
+                try:
+                    trainee_info = char_table.get(trainee_cid, {})
+                    profession = trainee_info.get("profession", "")
+                    if profession:
+                        route = _build_route_supports(profession)
+                        if route:
+                            supports_list = _supports_from_dicts(route)
+                except Exception as e:
+                    logger.warning(f"加载专精路线失败: {e}")
+
+            if state == TrainingState.TRAINING:
+                if supports_list:
+                    self._correct_assistant(
+                        trainer,
+                        trainee_cid,
+                        target_skill,
+                        char_table,
+                        supports_list,
+                        trainee_skill_label,
+                    )
+
+            if state == TrainingState.WAITING_COLLECT:
+                if not self._scheduler.find_next_task(
+                    task_type=TaskTypes.SKILL_UPGRADE
+                ):
+                    lvl = self._lit_zones + 1
+                    self._scheduler.tasks.append(
+                        SchedulerTask(
+                            time=datetime.now(),
+                            task_type=TaskTypes.SKILL_UPGRADE,
+                            meta_data=self._enrich_meta(
+                                trainee_skill_label, trainee_cid, lvl
+                            ),
+                            adjusted=True,
+                        )
+                    )
+
+            if target_skill >= 0:
+                if not plan_has_trainee and not self._scheduler.find_next_task(
+                    meta_data="_mastery"
+                ):
+                    logger.error(
+                        f"训练位干员 {trainee_name} skill_{trainee_skill_label}"
+                        f" 不在专精计划和一键专精上下文中"
+                    )
+                    return
+
+            if state == TrainingState.TRAINING and supports_list:
+                self._recover_half_off_chain(
+                    trainee_cid,
+                    target_skill,
+                    supports_list,
+                    trainee_skill_label,
+                )
+        except Exception:
+            pass
+
+    def _correct_assistant(
+        self,
+        trainer,
+        trainee_cid,
+        target_skill,
+        char_table,
+        supports_list,
+        trainee_skill_label,
+    ):
+        from arknights_mower.utils import config
+
+        if config.conf.assistant_follows_schedule:
+            logger.debug(
+                "assistant_follows_schedule enabled, skip assistant correction"
+            )
+            return
+        trainer_cid = trainer.get("charId")
+        trainer_name = (
+            char_table.get(trainer_cid, {}).get("name", trainer_cid)
+            if trainer_cid
+            else ""
+        )
+
+        half_off_names = {
+            s.swap_name for s in supports_list if s.swap_name and s.swap_name != s.name
+        }
+        if trainer_name and trainer_name in half_off_names:
+            if self._scheduler.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
+                return
+            if (
+                self._last_training_countdown
+                and self._last_training_countdown > datetime.now()
+            ):
+                remaining_h = (
+                    self._last_training_countdown - datetime.now()
+                ).total_seconds() / 3600
+                if remaining_h <= 5 + 10 / 60:
+                    return
+
+        current_level = self._lit_zones
+        if current_level == 0:
+            if not trainer_name:
+                correct = supports_list[0].name
+            elif trainer_name not in {s.name for s in supports_list}:
+                self._scheduler.tasks.append(
+                    SchedulerTask(
+                        time=datetime.now(),
+                        task_plan={"train": ["Free", "Current"]},
+                        meta_data="_mastery",
+                        adjusted=True,
+                    )
+                )
+                return
+            else:
+                correct = trainer_name
+        else:
+            training_lvl = current_level + 1
+            match = next(
+                (s for s in supports_list if s.level == training_lvl),
+                None,
+            )
+            correct = match.name if match else supports_list[0].name
+
+        logger.info(
+            f"训练室: 协助位={trainer_name}, "
+            f"当前等级={current_level}, 应为={correct}, "
+            f"路线={[s.name for s in supports_list]}"
+        )
+
+        if trainer_name != correct:
+            logger.warning(
+                f"协助位干员 {trainer_name} 不是当前等级的正确人选"
+                f"（应为 {correct}），创建换人任务"
+            )
+            self._scheduler.tasks.append(
+                SchedulerTask(
+                    time=datetime.now(),
+                    task_plan={"train": [correct, "Current"]},
+                    meta_data="_mastery",
+                    adjusted=True,
+                )
+            )
+            # 强制下次 sync 物理重读训练室
+            self._last_training_countdown = None
+            # 协助位纠正后排一个 REFRESH_TIME 触发换人时间计算
+            self._scheduler.tasks.append(
+                SchedulerTask(
+                    time=datetime.now() + timedelta(seconds=5),
+                    task_plan={},
+                    task_type=TaskTypes.REFRESH_TIME,
+                    meta_data="train",
+                )
+            )
+            existing = self._scheduler.find_next_task(
+                task_type=TaskTypes.SKILL_UPGRADE,
+                meta_data=trainee_skill_label,
+            )
+            if existing:
+                existing.time = datetime.now()
+
+    def _recover_half_off_chain(
+        self,
+        trainee_cid,
+        target_skill,
+        supports_list,
+        trainee_skill_label,
+    ):
+        from arknights_mower.utils import config
+
+        if config.conf.assistant_follows_schedule:
+            logger.debug(
+                "assistant_follows_schedule enabled, skip half-off chain recovery"
+            )
+            return
+        if (
+            self._last_training_countdown is None
+            or self._last_training_countdown <= datetime.now()
+        ):
+            return
+        try:
+            if self._lit_zones == 0:
+                training_lvl = 1
+            else:
+                training_lvl = self._lit_zones + 1
+            if training_lvl >= 3:
+                self._scheduler.tasks.append(
+                    SchedulerTask(
+                        time=self._last_training_countdown,
+                        task_type=TaskTypes.SKILL_UPGRADE,
+                        meta_data=self._enrich_meta(
+                            trainee_skill_label, trainee_cid, training_lvl
+                        ),
+                    )
+                )
+                return
+            support = next((s for s in supports_list if s.level == training_lvl), None)
+            if (
+                support is None
+                or not support.swap_name
+                or support.swap_name == support.name
+            ):
+                self._scheduler.tasks.append(
+                    SchedulerTask(
+                        time=self._last_training_countdown,
+                        task_type=TaskTypes.SKILL_UPGRADE,
+                        meta_data=self._enrich_meta(
+                            trainee_skill_label, trainee_cid, training_lvl
+                        ),
+                    )
+                )
+                return
+            remaining_h = (
+                self._last_training_countdown - datetime.now()
+            ).total_seconds() / 3600
+            swap_name = support.swap_name
+
+            # 等协助位纠正为正确人选后才能算换人
+            if self._trainer_name not in ("", support.name, swap_name):
+                return
+
+            # 读中枢加成
+            central_bonus = 0
+            try:
+                route_path = get_path("@app/tmp/matery_route.json")
+                if os.path.exists(route_path):
+                    with open(route_path, "r", encoding="utf-8") as _f:
+                        _route = json.load(_f)
+                    if _route.get("controlCenter", "none") != "none":
+                        central_bonus = 5
+            except Exception:
+                pass
+
+            if self._trainer_name == swap_name:
+                # 场景4：逻各斯/艾丽妮在位，剩余 > 5h10m → 换出再换入
+                if remaining_h <= 5 + 10 / 60:
+                    self._scheduler.tasks.append(
+                        SchedulerTask(
+                            time=self._last_training_countdown,
+                            task_type=TaskTypes.SKILL_UPGRADE,
+                            meta_data=self._enrich_meta(
+                                trainee_skill_label, trainee_cid, training_lvl
+                            ),
+                        )
+                    )
+                    return
+                self._scheduler.tasks.append(
+                    SchedulerTask(
+                        time=datetime.now(),
+                        task_plan={"train": [support.name, "Current"]},
+                        meta_data="_mastery",
+                        adjusted=True,
+                    )
+                )
+                self._scheduler.tasks.append(
+                    SchedulerTask(
+                        time=datetime.now() + timedelta(seconds=5),
+                        task_plan={},
+                        task_type=TaskTypes.REFRESH_TIME,
+                        meta_data="train",
+                    )
+                )
+                return
+
+            # _trainer_name == "" or support.name：反推换入后剩余
+            swap_match = support.match
+            current_total = 100 + support.efficiency + 5
+            swap_total = 100 + 5 + central_bonus + (30 if swap_match else 0)
+            projected = remaining_h * current_total / swap_total
+            if projected <= 5:
+                self._scheduler.tasks.append(
+                    SchedulerTask(
+                        time=self._last_training_countdown,
+                        task_type=TaskTypes.SKILL_UPGRADE,
+                        meta_data=self._enrich_meta(
+                            trainee_skill_label, trainee_cid, training_lvl
+                        ),
+                    )
+                )
+                return
+            self._scheduler._schedule_half_off_swap_internal(
+                support,
+                self._last_training_countdown,
+                trainee_skill_label,
+                check_duplicate=True,
+            )
+        except Exception:
+            pass

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -292,10 +292,18 @@ class RIICPart(ConfModel):
     "替换组心情监视"
     workshop_settings: list[WorkShopSetting] = []
     "工作室设置"
+    t5_operators: list[str] = ["年"]
+    "自动专精 T5 加工干员"
+    book_operators: list[str] = ["司霆惊蛰"]
+    "自动专精 技巧概要加工干员"
+    fodder_operators: list[str] = ["九色鹿"]
+    "自动专精 非 T5 材料加工干员"
     merge_interval: float = 10
     "不养闲人合并间隔"
     dorm_order: str = ""
     "宿舍优先级"
+    assistant_follows_schedule: bool = False
+    "协助位跟随排班（专精时协助位不固定，由排班系统管理）"
 
 
 class SimulatorPart(ConfModel):

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -279,8 +279,16 @@ def get_mastery_recommendations():
     return result
 
 
-def compute_workshop_config(t5_operator="年", book_operator="司霆惊蛰"):
+def compute_workshop_config(
+    fodder_operators=None, t5_operators=None, book_operators=None
+):
     """根据当前专精计划和仓库库存，计算合成配置（与前端自动合成配置逻辑一致）"""
+    if fodder_operators is None:
+        fodder_operators = ["九色鹿"]
+    if t5_operators is None:
+        t5_operators = ["年"]
+    if book_operators is None:
+        book_operators = ["司霆惊蛰"]
     from collections import defaultdict
 
     from arknights_mower.data import workshop_formula
@@ -325,59 +333,7 @@ def compute_workshop_config(t5_operator="年", book_operator="司霆惊蛰"):
     }
 
     if not planned_keys:
-        default_t4 = [
-            {"item_names": [n], "children_lower_limit": 20, "self_upper_limit": 20}
-            for n in sorted(t4_names)
-        ]
-        default_t5 = [
-            {"item_names": [n], "children_lower_limit": 20, "self_upper_limit": 20}
-            for n in sorted(t5_names)
-        ]
-        default_book = [
-            {
-                "item_names": ["技巧概要·卷3"],
-                "children_lower_limit": 20,
-                "self_upper_limit": 20,
-            }
-        ]
-        return [
-            {"operator": "九色鹿", "enabled": True, "items": fodder_items + default_t4},
-            {"operator": t5_operator, "enabled": True, "items": default_t5},
-            {"operator": book_operator, "enabled": True, "items": default_book},
-        ]
-
-    t4_names = {
-        n: e
-        for n, e in workshop_formula.items()
-        if e.get("tab") == "精英材料" and e.get("apCost") == 4.0
-    }
-    t5_names = {
-        n: e
-        for n, e in workshop_formula.items()
-        if e.get("tab") == "精英材料" and e.get("apCost") == 8.0
-    }
-
-    if not planned_keys:
-        default_t4 = [
-            {"item_names": [n], "children_lower_limit": 20, "self_upper_limit": 20}
-            for n in sorted(t4_names)
-        ]
-        default_t5 = [
-            {"item_names": [n], "children_lower_limit": 20, "self_upper_limit": 20}
-            for n in sorted(t5_names)
-        ]
-        default_book = [
-            {
-                "item_names": ["技巧概要·卷3"],
-                "children_lower_limit": 20,
-                "self_upper_limit": 20,
-            }
-        ]
-        return [
-            {"operator": "九色鹿", "enabled": True, "items": fodder_items + default_t4},
-            {"operator": "年", "enabled": True, "items": default_t5},
-            {"operator": "司霆惊蛰", "enabled": True, "items": default_book},
-        ]
+        return None
 
     rec_result = get_mastery_recommendations()
     operators = rec_result.get("operators", [])
@@ -469,11 +425,80 @@ def compute_workshop_config(t5_operator="年", book_operator="司霆惊蛰"):
         else []
     )
 
-    return [
-        {"operator": "九色鹿", "enabled": True, "items": fodder_items + t4_items},
-        {"operator": "年", "enabled": True, "items": t5_items},
-        {"operator": "司霆惊蛰", "enabled": True, "items": book_items},
+    return (
+        [
+            {"operator": op, "enabled": True, "items": fodder_items + t4_items}
+            if op == "九色鹿"
+            else {"operator": op, "enabled": True, "items": t4_items}
+            for op in fodder_operators
+        ]
+        + [{"operator": op, "enabled": True, "items": t5_items} for op in t5_operators]
+        + [
+            {"operator": op, "enabled": True, "items": book_items}
+            for op in book_operators
+        ]
+    )
+
+
+def compute_default_workshop_config(
+    fodder_operators=None, t5_operators=None, book_operators=None
+):
+    """无专精计划时的全量默认合成配置（包含全 T4+T5+技巧概要）"""
+    if fodder_operators is None:
+        fodder_operators = ["九色鹿"]
+    if t5_operators is None:
+        t5_operators = ["年"]
+    if book_operators is None:
+        book_operators = ["司霆惊蛰"]
+    from arknights_mower.data import workshop_formula
+
+    t4_names = {
+        n
+        for n, e in workshop_formula.items()
+        if e.get("tab") == "精英材料" and e.get("apCost") == 4.0
+    }
+    t5_names = {
+        n
+        for n, e in workshop_formula.items()
+        if e.get("tab") == "精英材料" and e.get("apCost") == 8.0
+    }
+    fodder_list = ["碳素", "碳素组", "家具零件_碳素组"]
+    fodder_items = [
+        {"item_names": [f], "children_lower_limit": 0, "self_upper_limit": 9999}
+        for f in fodder_list
+        if f in workshop_formula
     ]
+    default_t4 = [
+        {"item_names": [n], "children_lower_limit": 20, "self_upper_limit": 20}
+        for n in sorted(t4_names)
+    ]
+    default_t5 = [
+        {"item_names": [n], "children_lower_limit": 20, "self_upper_limit": 20}
+        for n in sorted(t5_names)
+    ]
+    default_book = [
+        {
+            "item_names": ["技巧概要·卷3"],
+            "children_lower_limit": 20,
+            "self_upper_limit": 20,
+        }
+    ]
+    return (
+        [
+            {"operator": op, "enabled": True, "items": fodder_items + default_t4}
+            if op == "九色鹿"
+            else {"operator": op, "enabled": True, "items": default_t4}
+            for op in fodder_operators
+        ]
+        + [
+            {"operator": op, "enabled": True, "items": default_t5}
+            for op in t5_operators
+        ]
+        + [
+            {"operator": op, "enabled": True, "items": default_book}
+            for op in book_operators
+        ]
+    )
 
 
 _default_route_cache = None
@@ -511,9 +536,7 @@ def _build_route_supports(profession, control_center="none"):
     prof_route = route.get(prof_cn, prof_default)
     supports_data = prof_route.get("supports", []) or prof_default.get("supports", [])
     half_off = prof_route.get("half_off", prof_default.get("half_off", True))
-    cc = control_center or prof_route.get(
-        "controlCenter", prof_default.get("controlCenter", "none")
-    )
+    cc = control_center or route.get("controlCenter", "none")
     bonus = 0 if cc == "none" else 5
     supports = []
     for s in supports_data:
@@ -628,6 +651,7 @@ def auto_schedule_mastery_tasks():
                 "skill_index": rec["skill_index"],
                 "skill_name": rec["skill_name"],
                 "achievable": all_materials_sufficient,
+                "current_level": rec.get("current_level", 0),
             }
             if all_materials_sufficient:
                 result["scheduled"].append(entry)

--- a/arknights_mower/utils/operators.py
+++ b/arknights_mower/utils/operators.py
@@ -102,7 +102,6 @@ class SkillUpgradeSupport:
     level = 1
     efficiency = 0
     half_off = False
-    add_on = False
     match = False
     use_booster = True
     name = ""
@@ -165,34 +164,6 @@ class Operators:
 
     def __repr__(self):
         return f"Operators(operators={self.operators})"
-
-    def calculate_switch_time(self, support: SkillUpgradeSupport):
-        hour = 0
-        half_off = support.half_off
-        level = support.level
-        match = support.match
-        efficiency = support.efficiency
-        same = support.name == support.swap_name
-        if level == 1:
-            half_off = False
-        # if left_minutes > 0 or left_hours > 0:
-        #     hour = left_minutes / 60 + left_hours
-        # 基本5%
-        basic = 5
-        if support.add_on:
-            # 阿斯卡纶
-            basic += 5
-        if hour == 0:
-            hour = level * 8
-        if half_off:
-            hour = hour / 2
-        left = 0
-        if not same:
-            left = 5 * (100 + basic + (30 if match else 0)) / 100
-            left = hour - left
-        else:
-            left = hour
-        return left * 100 / (100 + efficiency + basic)
 
     def swap_plan(self, condition, refresh=False):
         self.plan = copy.deepcopy(self.global_plan["default_plan"].plan)

--- a/server.py
+++ b/server.py
@@ -821,13 +821,29 @@ def mastery_recommendation():
 def workshop_auto_config():
     import traceback
 
-    from arknights_mower.utils.mastery_recommendation import compute_workshop_config
+    from arknights_mower.utils.mastery_recommendation import (
+        compute_default_workshop_config,
+        compute_workshop_config,
+    )
 
     try:
         req = request.json or {}
-        t5_op = req.get("t5_operator", "年")
-        book_op = req.get("book_operator", "司霆惊蛰")
-        settings = compute_workshop_config(t5_operator=t5_op, book_operator=book_op)
+        fodder_ops = req.get("fodder_operators", ["九色鹿"])
+        t5_ops = req.get("t5_operators", ["年"])
+        book_ops = req.get("book_operators", ["司霆惊蛰"])
+        planned_skills = req.get("planned_skills", [])
+        if planned_skills:
+            settings = compute_workshop_config(
+                fodder_operators=fodder_ops,
+                t5_operators=t5_ops,
+                book_operators=book_ops,
+            )
+        else:
+            settings = compute_default_workshop_config(
+                fodder_operators=fodder_ops,
+                t5_operators=t5_ops,
+                book_operators=book_ops,
+            )
         return {"workshop_settings": settings, "t3_summary": []}
     except Exception as e:
         return {"error": str(e), "traceback": traceback.format_exc()}, 500

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -17,28 +17,16 @@
           <template #icon><n-icon :component="SettingsIcon" /></template>
           专精路线
         </n-button>
+        <n-button size="small" @click="showWorkshopSettings = true">
+          <template #icon><n-icon :component="SettingsIcon" /></template>
+          加工站干员设置
+        </n-button>
         <n-button size="small" type="warning" @click="autoWorkshop" :loading="workshopLoading">
           <template #icon><n-icon :component="HammerIcon" /></template>
           自动合成配置
         </n-button>
         <n-button size="small" @click="savePreset">保存合成配置</n-button>
         <n-button size="small" @click="restorePreset">还原合成配置</n-button>
-        <n-select
-          v-model:value="t5Operator"
-          :options="operatorOptions"
-          filterable
-          placeholder="T5合成干员"
-          style="width: 120px"
-          size="small"
-        />
-        <n-select
-          v-model:value="bookOperator"
-          :options="operatorOptions"
-          filterable
-          placeholder="技巧概要干员"
-          style="width: 120px"
-          size="small"
-        />
         <n-button type="primary" size="small" @click="fetchCultivate" :loading="store.loading">
           <template #icon><n-icon :component="RefreshIcon" /></template>
           刷新
@@ -443,6 +431,41 @@
         </n-space>
       </template>
     </n-modal>
+
+    <!-- 加工站干员设置 -->
+    <n-modal
+      v-model:show="showWorkshopSettings"
+      preset="card"
+      title="加工站干员设置"
+      style="width: min(500px, 95vw)"
+      :mask-closable="false"
+    >
+      <n-space vertical>
+        <div>
+          <n-text depth="3">非 T5 材料加工干员</n-text>
+          <help-text>
+            选择 九色鹿 时会自动添加 碳素，碳素组，家具零件_碳素组 作为垫刀材料
+          </help-text>
+        </div>
+        <slick-operator-select
+          v-model="fodderOps"
+          :disabled="false"
+          select_placeholder="选择干员（九色鹿带垫刀材料）"
+        />
+        <n-text depth="3">T5 加工干员</n-text>
+        <slick-operator-select v-model="t5Ops" :disabled="false" select_placeholder="选择干员" />
+        <n-text depth="3">技巧概要加工干员</n-text>
+        <slick-operator-select v-model="bookOps" :disabled="false" select_placeholder="选择干员" />
+      </n-space>
+      <template #footer>
+        <n-space justify="end">
+          <n-button size="small" @click="resetWorkshopDefaults">恢复默认</n-button>
+          <n-button type="primary" size="small" @click="showWorkshopSettings = false"
+            >保存</n-button
+          >
+        </n-space>
+      </template>
+    </n-modal>
   </div>
 </template>
 
@@ -528,9 +551,19 @@ const filterProfession = ref([])
 const filterAchievable = ref(false)
 const showOnlyPlanned = ref(false)
 const decomposeT3 = ref(false)
+const {
+  fodder_operators: fodderOps,
+  t5_operators: t5Ops,
+  book_operators: bookOps
+} = storeToRefs(configStore)
 const workshopLoading = ref(false)
-const t5Operator = ref('年')
-const bookOperator = ref('司霆惊蛰')
+const showWorkshopSettings = ref(false)
+
+function resetWorkshopDefaults() {
+  fodderOps.value = ['九色鹿']
+  t5Ops.value = ['年']
+  bookOps.value = ['司霆惊蛰']
+}
 const workshopT3Summary = ref([])
 
 const emptyText = computed(() => {
@@ -616,10 +649,12 @@ const filteredPlanOperators = computed(() => {
 
 async function savePreset() {
   try {
-    await axios.post(
-      `${import.meta.env.VITE_HTTP_URL}/workshop-preset`,
-      configStore.workshop_settings
-    )
+    await axios.post(`${import.meta.env.VITE_HTTP_URL}/workshop-preset`, {
+      settings: configStore.workshop_settings,
+      fodder_operators: fodderOps.value,
+      t5_operators: t5Ops.value,
+      book_operators: bookOps.value
+    })
     message.success('当前合成配置已保存为默认')
   } catch (e) {
     message.error('保存失败: ' + e.message)
@@ -628,8 +663,12 @@ async function savePreset() {
 async function restorePreset() {
   try {
     const r = await axios.get(`${import.meta.env.VITE_HTTP_URL}/workshop-preset`)
-    if (r.data && r.data.length) {
-      configStore.workshop_settings = r.data
+    const data = r.data
+    if (data && (data.settings?.length || data.length)) {
+      configStore.workshop_settings = data.settings || data
+      if (data.fodder_operators) fodderOps.value = data.fodder_operators
+      if (data.t5_operators) t5Ops.value = data.t5_operators
+      if (data.book_operators) bookOps.value = data.book_operators
       await new Promise((res) => setTimeout(res, 100))
       await axios.post(`${import.meta.env.VITE_HTTP_URL}/conf`, configStore.build_config())
       message.success('合成配置已还原')
@@ -647,13 +686,17 @@ async function autoWorkshop() {
     const keys = Object.keys(plan.value).filter((k) => plan.value[k])
     const resp = await axios.post(`${import.meta.env.VITE_HTTP_URL}/workshop-auto-config`, {
       planned_skills: keys,
-      t5_operator: t5Operator.value,
-      book_operator: bookOperator.value
+      fodder_operators: fodderOps.value,
+      t5_operators: t5Ops.value,
+      book_operators: bookOps.value
     })
     const ws = resp.data?.workshop_settings
     if (!ws) {
       message.warning('生成失败')
       return
+    }
+    if (keys.length === 0) {
+      message.success('当前没有专精计划，已自动生成全量合成方案')
     }
     configStore.workshop_settings = ws
 
@@ -748,6 +791,10 @@ function newSupport(p) {
   const def = defaultsCache.value
   if (!def) return null
   if (!routeSettings[p].optimal) {
+    if (i >= 3) {
+      const ref = def[p]?.supports?.find((s) => s.skill_level >= 3)
+      if (ref) return { ...ref, swap: true }
+    }
     const backups = def._backups || {}
     const name = backups[p] || ''
     if (!name) return null

--- a/ui/src/pages/Settings.vue
+++ b/ui/src/pages/Settings.vue
@@ -42,6 +42,7 @@ const {
   free_room,
   merge_interval,
   fia_fool,
+  assistant_follows_schedule,
   droidcast,
   mumu12IPC,
   maa_adb_path,
@@ -664,6 +665,14 @@ if (return_home_when_idle.value) {
                 菲亚防呆
                 <help-text
                   >当菲亚替换干员心情均超过90%时菲亚等待半小时，不确定菲亚替换心情消耗请启用本选项</help-text
+                >
+              </n-checkbox>
+            </n-form-item>
+            <n-form-item :show-label="false">
+              <n-checkbox v-model:checked="assistant_follows_schedule">
+                训练室协助位总是跟随排班
+                <help-text
+                  >勾选后专精时的协助位不会使用设置的专精工具人，在基建排班时会根据排班表来替换训练室的协助位。</help-text
                 >
               </n-checkbox>
             </n-form-item>

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -42,6 +42,9 @@ export const useConfigStore = defineStore('config', () => {
   const rescue_threshold = ref(75)
   const favorite = ref([])
   const workshop_settings = ref([])
+  const fodder_operators = ref(['九色鹿'])
+  const t5_operators = ref(['年'])
+  const book_operators = ref(['司霆惊蛰'])
   const theme = ref('light')
   const tap_to_launch_game = ref(false)
   const exit_game_when_idle = ref(true)
@@ -83,6 +86,7 @@ export const useConfigStore = defineStore('config', () => {
   const free_room = ref(false)
   const merge_interval = ref(10)
   const fia_fool = ref(true)
+  const assistant_follows_schedule = ref(false)
   const sign_in = ref({ enable: true })
   const droidcast = ref({})
   const mumu12IPC = ref(false)
@@ -305,6 +309,7 @@ export const useConfigStore = defineStore('config', () => {
     free_room.value = response.data.free_room
     merge_interval.value = response.data.merge_interval
     fia_fool.value = response.data.fia_fool
+    assistant_follows_schedule.value = response.data.assistant_follows_schedule
     sign_in.value = response.data.sign_in
     droidcast.value = response.data.droidcast
     mumu12IPC.value = response.data.mumu12IPC
@@ -312,6 +317,9 @@ export const useConfigStore = defineStore('config', () => {
     credit_fight.value = response.data.credit_fight
     custom_screenshot.value = response.data.custom_screenshot
     workshop_settings.value = response.data.workshop_settings
+    fodder_operators.value = response.data.fodder_operators || ['九色鹿']
+    t5_operators.value = response.data.t5_operators || ['年']
+    book_operators.value = response.data.book_operators || ['司霆惊蛰']
     check_for_updates.value = response.data.check_for_updates
     notification_level.value = response.data.notification_level
     waiting_scene.value = response.data.waiting_scene
@@ -407,6 +415,7 @@ export const useConfigStore = defineStore('config', () => {
       free_room: free_room.value,
       merge_interval: merge_interval.value,
       fia_fool: fia_fool.value,
+      assistant_follows_schedule: assistant_follows_schedule.value,
       sign_in: sign_in.value,
       droidcast: droidcast.value,
       mumu12IPC: mumu12IPC.value,
@@ -414,6 +423,9 @@ export const useConfigStore = defineStore('config', () => {
       credit_fight: credit_fight.value,
       custom_screenshot: custom_screenshot.value,
       workshop_settings: workshop_settings.value,
+      fodder_operators: fodder_operators.value,
+      t5_operators: t5_operators.value,
+      book_operators: book_operators.value,
       check_for_updates: check_for_updates.value,
       notification_level: notification_level.value,
       waiting_scene: waiting_scene.value,
@@ -496,6 +508,9 @@ export const useConfigStore = defineStore('config', () => {
     rescue_threshold,
     favorite,
     workshop_settings,
+    fodder_operators,
+    t5_operators,
+    book_operators,
     theme,
     tap_to_launch_game,
     exit_game_when_idle,
@@ -537,6 +552,7 @@ export const useConfigStore = defineStore('config', () => {
     free_room,
     merge_interval,
     fia_fool,
+    assistant_follows_schedule,
     sign_in,
     droidcast,
     mumu12IPC,


### PR DESCRIPTION
# 改动

### 专精调度重构
- **训练室状态机** `training_state.py`：IDLE / TRAINING / WAITING_COLLECT 三状态，带缓存防抖
- **技能检测**：进入技能选择页 → 检测框亮度 → 最低值定位当前训练技能
- **游戏内读取**：启动后自动进训练室读倒计时、检测技能等级，不再依赖森空岛 API
- **恢复路径**：`gate_sync()` 在专精计划存在时自动恢复训练室任务、协助位纠错
- **减半换人**：`_schedule_half_off_swap_internal` 统一入口，根据效率自动计算换人时间
- **协助位纠错**：`_correct_assistant` 增加减半干员在位且剩余 ≤5h10m 时不纠错
- **M3 自动排下一专精**：完成专三后自动从计划中取下一项
- **已完成专精黑名单**：`_completed_masteries` 防止重复安排
- **清理**：移除 `_check_mastery_plan_conflict`、`_should_skip_train_room`、`_verify_and_recover_mastery_room`、`calculate_switch_time`、`add_on`
- **修复**：`report.py` 中修改 `if` -> `elif`，防止邮件发送基建报告时缺失龙舌兰赤金
- **修复**: 修复无专精计划时重复安排可能不需要的加工任务

### 加工站配置
- `conf.py` 新增 `fodder_operators` / `t5_operators` / `book_operators`，支持多干员
- 新增 `compute_default_workshop_config`，无专精计划时生成全量合成方案
- 前端专精页新增加工站干员设置弹窗（替换原来两个独立下拉框）

### 协助位设置
- 新增 `assistant_follows_schedule`，勾选后训练室协助位由排班系统管理而非固定工具人

### TODO
- [ ] 减半换人任务优先级