### PR TITLE
feat: 新增 MAA 连通性检查与启动前检测

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
 - 新增基建设置 `训练室协助位总是跟随排班`
 - 新增自动合成配置的默认加工站干员设置
 - 新增无专精计划时可使用自动合成配置添加全量材料合成配置
+- 新增 MAA 连通性测试的子进程执行与启动前检查选项，并在连接配置中提示 MuMu Mac 用户可切换 `MuMuMacStable`
 - 移除专精计划与排班表的冲突检测
 
 详细内容：
 ### 新增 feat
 - feat: 重构全自动专精调度、增加加工站干员配置并修复邮件和无法删除的加工配置问题 [(#873)@NiceAfternoon](https://github.com/ArkMowers/arknights-mower/commit/8a000046167caa90d40c9e526e98f6310d76ed0c)
+- feat: 新增 MAA 连通性测试的子进程执行与启动前检查，并提示 MuMu Mac 用户可切换 `MuMuMacStable` 连接配置 [@ALEXsun0]
 
 ## 4.1.5.5
 

--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -12,6 +12,10 @@ from arknights_mower.utils.device.adb_client.session import Session
 from arknights_mower.utils.device.scrcpy import Scrcpy
 from arknights_mower.utils.email import send_message, task_template
 from arknights_mower.utils.log import logger
+from arknights_mower.utils.maa_check import (
+    run_maa_connectivity_check,
+    should_check_maa_before_start,
+)
 from arknights_mower.utils.news_checker import NewsChecker
 from arknights_mower.utils.operators import Operator
 from arknights_mower.utils.path import get_path
@@ -23,6 +27,13 @@ base_scheduler = None
 # 执行自动排班
 def main(saved_state):
     logger.info("开始运行Mower")
+    if should_check_maa_before_start():
+        logger.info("启动前测试Maa连接")
+        result = run_maa_connectivity_check()
+        if result["status"] != "success":
+            logger.error(f"启动前Maa连接测试失败：{result['message']}")
+            return
+        logger.info(f"启动前Maa连接测试通过：{result['message']}")
     rapidocr.initialize_ocr()
     data = None
     if saved_state != {}:

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -184,6 +184,8 @@ class MaaPart(ConfModel):
     maa_path: str = "D:\\MAA-v4.13.0-win-x64"
     maa_conn_preset: str = "General"
     maa_touch_option: str = "maatouch"
+    maa_startup_check: bool = False
+    "启动Mower前测试Maa连通性"
 
 
 class RecruitPart(ConfModel):

--- a/arknights_mower/utils/maa_check.py
+++ b/arknights_mower/utils/maa_check.py
@@ -1,0 +1,110 @@
+import json
+import subprocess
+import sys
+
+from arknights_mower import __system__
+from arknights_mower.utils import config
+
+MAA_CHECK_TIMEOUT = 30
+
+MAA_CHECK_SCRIPT = r"""
+import json
+import pathlib
+import sys
+
+params = json.loads(sys.argv[1])
+try:
+    maa_path = pathlib.Path(params["maa_path"])
+    sys.path.append(str(maa_path / "Python"))
+
+    from asst.asst import Asst
+
+    def callback(msg, details, arg):
+        pass
+
+    callback_func = Asst.CallBackType(callback)
+    Asst.load(str(maa_path))
+    asst = Asst(callback=callback_func)
+    version = asst.get_version()
+    asst.set_instance_option(2, params["maa_touch_option"])
+    if asst.connect(params["maa_adb_path"], params["adb"], params["maa_conn_preset"]):
+        result = {"status": "success", "message": f"Maa {version} 连接成功"}
+    else:
+        result = {"status": "failed", "message": "连接失败，请检查Maa日志！"}
+except Exception as e:
+    result = {"status": "failed", "message": "Maa加载失败：" + str(e)}
+
+print(json.dumps(result, ensure_ascii=False))
+"""
+
+
+def maa_check_params() -> dict[str, str]:
+    return {
+        "maa_path": str(config.conf.maa_path),
+        "maa_adb_path": str(config.conf.maa_adb_path),
+        "adb": str(config.conf.adb),
+        "maa_conn_preset": str(config.conf.maa_conn_preset),
+        "maa_touch_option": str(config.conf.maa_touch_option),
+    }
+
+
+def maa_check_command(params: dict[str, str] | None = None) -> list[str]:
+    return [
+        sys.executable,
+        "-c",
+        MAA_CHECK_SCRIPT,
+        json.dumps(params or maa_check_params(), ensure_ascii=False),
+    ]
+
+
+def parse_maa_check_output(
+    stdout: str, stderr: str = "", returncode: int | None = None
+) -> dict[str, str]:
+    for line in reversed(stdout.splitlines()):
+        try:
+            result = json.loads(line)
+            return {
+                "status": result.get("status", "failed"),
+                "message": result.get("message", ""),
+            }
+        except json.JSONDecodeError:
+            pass
+
+    message = "Maa测试进程异常退出"
+    if returncode is not None:
+        message += f"：{returncode}"
+    if stderr.strip():
+        message += f"，{stderr.strip().splitlines()[-1]}"
+    return {"status": "failed", "message": message}
+
+
+def maa_check_timeout_result(timeout: int = MAA_CHECK_TIMEOUT) -> dict[str, str]:
+    return {
+        "status": "failed",
+        "message": f"Maa连通性测试超时（{timeout}秒），已终止测试进程",
+    }
+
+
+def run_maa_connectivity_check(
+    timeout: int = MAA_CHECK_TIMEOUT,
+) -> dict[str, str]:
+    try:
+        result = subprocess.run(
+            maa_check_command(),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            creationflags=(
+                subprocess.CREATE_NO_WINDOW if __system__ == "windows" else 0
+            ),
+        )
+    except subprocess.TimeoutExpired:
+        return maa_check_timeout_result(timeout)
+    except Exception as e:
+        return {"status": "failed", "message": "Maa测试启动失败：" + str(e)}
+
+    return parse_maa_check_output(result.stdout, result.stderr, result.returncode)
+
+
+def should_check_maa_before_start() -> bool:
+    return bool(getattr(config.conf, "maa_startup_check", False))

--- a/server.py
+++ b/server.py
@@ -3,8 +3,7 @@ import datetime
 import json
 import mimetypes
 import os
-import pathlib
-import sys
+import subprocess
 import time
 from functools import wraps
 from io import BytesIO
@@ -24,6 +23,12 @@ from arknights_mower.solvers.record import clear_data, load_state, save_state
 from arknights_mower.utils import config
 from arknights_mower.utils.datetime import get_server_time
 from arknights_mower.utils.log import logger
+from arknights_mower.utils.maa_check import (
+    MAA_CHECK_TIMEOUT,
+    maa_check_command,
+    maa_check_timeout_result,
+    parse_maa_check_output,
+)
 from arknights_mower.utils.operators import Operators, build_global_plan
 from arknights_mower.utils.path import get_path
 
@@ -52,6 +57,50 @@ if token := config.conf.webview.token:
 mower_thread = None
 log_lines = []
 ws_connections = []
+maa_check_job = {
+    "id": None,
+    "process": None,
+    "status": "idle",
+    "message": "",
+    "started_at": None,
+}
+
+
+def _collect_maa_check_result():
+    process = maa_check_job.get("process")
+    if process is None:
+        return
+
+    if process.poll() is None:
+        started_at = maa_check_job.get("started_at")
+        if started_at and time.monotonic() - started_at > MAA_CHECK_TIMEOUT:
+            process.kill()
+            try:
+                process.communicate(timeout=1)
+            except Exception:
+                pass
+            result = maa_check_timeout_result(MAA_CHECK_TIMEOUT)
+            maa_check_job.update(
+                {
+                    "process": None,
+                    "status": result["status"],
+                    "message": result["message"],
+                    "started_at": None,
+                }
+            )
+        return
+
+    stdout, stderr = process.communicate()
+    result = parse_maa_check_output(stdout, stderr, process.returncode)
+
+    maa_check_job.update(
+        {
+            "process": None,
+            "status": result["status"],
+            "message": result["message"],
+            "started_at": None,
+        }
+    )
 
 
 def read_log():
@@ -434,26 +483,40 @@ def validate_backup_plans_route():
 @app.route("/check-maa")
 @require_token
 def get_maa_adb_version():
-    try:
-        asst_path = os.path.dirname(
-            pathlib.Path(config.conf.maa_path) / "Python" / "asst"
-        )
-        if asst_path not in sys.path:
-            sys.path.append(asst_path)
-        from asst.asst import Asst
+    _collect_maa_check_result()
+    if maa_check_job["status"] == "running":
+        return {
+            "status": "running",
+            "message": maa_check_job["message"] or "正在测试……",
+        }
 
-        Asst.load(config.conf.maa_path)
-        asst = Asst()
-        version = asst.get_version()
-        asst.set_instance_option(2, config.conf.maa_touch_option)
-        if asst.connect(config.conf.maa_adb_path, config.conf.adb):
-            maa_msg = f"Maa {version} 加载成功"
-        else:
-            maa_msg = "连接失败，请检查Maa日志！"
-    except Exception as e:
-        maa_msg = "Maa加载失败：" + str(e)
-        logger.exception(maa_msg)
-    return maa_msg
+    process = subprocess.Popen(
+        maa_check_command(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        creationflags=subprocess.CREATE_NO_WINDOW if __system__ == "windows" else 0,
+    )
+    maa_check_job.update(
+        {
+            "id": time.time_ns(),
+            "process": process,
+            "status": "running",
+            "message": "正在测试……",
+            "started_at": time.monotonic(),
+        }
+    )
+    return {"status": "running", "message": "正在测试……"}
+
+
+@app.route("/check-maa/status")
+@require_token
+def get_maa_check_status():
+    _collect_maa_check_result()
+    return {
+        "status": maa_check_job["status"],
+        "message": maa_check_job["message"],
+    }
 
 
 @app.route("/maa-conn-preset")

--- a/ui/src/components/MaaBasic.vue
+++ b/ui/src/components/MaaBasic.vue
@@ -8,9 +8,11 @@ import { useConfigStore } from '@/stores/config'
 const store = useConfigStore()
 
 import { storeToRefs } from 'pinia'
-const { maa_path, maa_conn_preset, maa_touch_option } = storeToRefs(store)
+const { maa_path, maa_conn_preset, maa_touch_option, maa_startup_check } = storeToRefs(store)
 
 import { folder_dialog } from '@/utils/dialog'
+
+const MUMU_MAC_STABLE = 'MuMuMacStable'
 
 async function select_maa_dir() {
   const folder_path = await folder_dialog()
@@ -20,11 +22,39 @@ async function select_maa_dir() {
 }
 
 const maa_msg = ref('')
+const maa_testing = ref(false)
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 async function test_maa() {
+  if (maa_testing.value) return
+  maa_testing.value = true
   maa_msg.value = '正在测试……'
-  const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/check-maa`)
-  maa_msg.value = response.data
+  try {
+    let response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/check-maa`)
+    let data = response.data
+    if (typeof data === 'string') {
+      maa_msg.value = data
+      return
+    }
+    while (data.status === 'running') {
+      maa_msg.value = data.message || '正在测试……'
+      await sleep(1000)
+      response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/check-maa/status`)
+      data = response.data
+      if (typeof data === 'string') {
+        maa_msg.value = data
+        return
+      }
+    }
+    maa_msg.value = data.message || '测试失败，请检查Maa日志！'
+  } catch (error) {
+    maa_msg.value = `测试失败：${error.message}`
+  } finally {
+    maa_testing.value = false
+  }
 }
 
 const maa_conn_presets = ref([])
@@ -32,7 +62,8 @@ const maa_conn_presets = ref([])
 async function get_maa_conn_presets() {
   const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-conn-preset`)
   maa_conn_presets.value = response.data.map((x) => {
-    return { label: x, value: x }
+    const label = x === MUMU_MAC_STABLE ? `${x}（MuMu Mac 推荐）` : x
+    return { label, value: x }
   })
 }
 
@@ -61,10 +92,15 @@ const maa_touch_options = ['maatouch', 'minitouch', 'adb'].map((x) => {
       <n-form-item label="触控模式">
         <n-select v-model:value="maa_touch_option" :options="maa_touch_options" />
       </n-form-item>
+      <n-form-item label="启动前测试">
+        <n-checkbox v-model:checked="maa_startup_check">启动Mower前测试Maa连接</n-checkbox>
+      </n-form-item>
     </n-form>
     <n-divider />
     <div class="misc-container">
-      <n-button @click="test_maa">测试设置</n-button>
+      <n-button :loading="maa_testing" :disabled="maa_testing" @click="test_maa">
+        测试连接
+      </n-button>
       <div>{{ maa_msg }}</div>
     </div>
   </n-card>

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -14,6 +14,7 @@ export const useConfigStore = defineStore('config', () => {
   const maa_adb_path = ref('')
   const maa_enable = ref(false)
   const maa_path = ref('')
+  const maa_startup_check = ref(false)
   const maa_expiring_medicine = ref(true)
   const maa_weekly_plan = ref([])
   const maa_weekly_plan_options = ref([])
@@ -240,6 +241,7 @@ export const useConfigStore = defineStore('config', () => {
     maa_adb_path.value = response.data.maa_adb_path
     maa_enable.value = response.data.maa_enable != 0
     maa_path.value = response.data.maa_path
+    maa_startup_check.value = response.data.maa_startup_check
     maa_rg_enable.value = response.data.maa_rg_enable == 1
     maa_long_task_type.value = response.data.maa_long_task_type
     maa_expiring_medicine.value = response.data.maa_expiring_medicine
@@ -345,6 +347,7 @@ export const useConfigStore = defineStore('config', () => {
       maa_adb_path: maa_adb_path.value,
       maa_enable: maa_enable.value ? 1 : 0,
       maa_path: maa_path.value,
+      maa_startup_check: maa_startup_check.value,
       maa_rg_enable: maa_rg_enable.value ? 1 : 0,
       maa_long_task_type: maa_long_task_type.value,
       maa_expiring_medicine: maa_expiring_medicine.value,
@@ -477,6 +480,7 @@ export const useConfigStore = defineStore('config', () => {
     maa_adb_path,
     maa_enable,
     maa_path,
+    maa_startup_check,
     maa_rg_enable,
     maa_long_task_type,
     maa_expiring_medicine,


### PR DESCRIPTION
## 摘要

- 新增 `maa_check` 工具模块，将 MAA 加载与连接测试放到子进程中执行
- 将 `/check-maa` 改为异步测试接口，并新增轮询状态接口，避免 UI 被 MAA 加载过程阻塞
- 新增“启动 Mower 前测试 MAA 连接”配置项，连接失败时中止启动并输出错误日志
- 在 MAA 设置页增加启动前测试开关，并优化测试按钮的 loading 与失败提示
- 在连接配置下拉框中标注 `MuMuMacStable` 为 MuMu Mac 推荐项，用户可手动切换，默认值仍保持 `General`
- 补充 `CHANGELOG.md` 说明

## 背景

在 macOS 环境下，MAA 的加载和连接测试如果直接在主进程中执行，遇到环境异常或加载较慢时容易造成界面卡顿，失败信息也不够明确。

这次改动把 MAA 连通性测试隔离到子进程中执行，并为前端提供明确的 `running` / `success` / `failed` 状态，减少测试过程对主服务和 UI 的影响。MAA 上游提供的 `MuMuMacStable` 连接配置对 MuMu Mac 的 NC 截图连接更合适，因此在连接配置列表中增加推荐提示，但不自动改动用户默认连接配置。

## 验证

- `git diff --check`
- `uvx ruff check .`
- `uvx ruff format --check .`
- `npx --yes prettier@latest --check "ui/**/*.js" "ui/**/*.vue"`
- `python3 -m compileall arknights_mower server.py`
