### PR TITLE
fix: 统一任务间休眠收口，修复休息期间 /status 的 sleeping 状态

### DIFF
--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -6,11 +6,10 @@ from arknights_mower.solvers.reclamation_algorithm import ReclamationAlgorithm
 from arknights_mower.solvers.secret_front import SecretFront
 from arknights_mower.utils import config, path, rapidocr
 from arknights_mower.utils.csleep import MowerExit
-from arknights_mower.utils.datetime import format_time, get_server_time
+from arknights_mower.utils.datetime import get_server_time
 from arknights_mower.utils.depot import 创建csv, 创建json
 from arknights_mower.utils.device.adb_client.session import Session
 from arknights_mower.utils.device.scrcpy import Scrcpy
-from arknights_mower.utils.email import send_message, task_template
 from arknights_mower.utils.log import logger
 from arknights_mower.utils.maa_check import (
     run_maa_connectivity_check,
@@ -127,7 +126,6 @@ def simulate(saved, restart_after_mood_read=False):
     if not validation_msg["success"]:
         logger.error(f"备用计划验证失败: {validation_msg['message']}")
         return
-    timezone_offset = config.conf.timezone_offset
     if saved:
         try:
             for k, v in saved["operators"].items():
@@ -254,13 +252,6 @@ def simulate(saved, restart_after_mood_read=False):
                         context = f"下一次任务:{base_scheduler.tasks[0].plan}"
                         logger.info(context)
                         logger.info(subject)
-                        body = task_template.render(
-                            tasks=[
-                                obj.format(timezone_offset)
-                                for obj in base_scheduler.tasks
-                            ],
-                            base_scheduler=base_scheduler,
-                        )
                         base_scheduler.maa_plan_solver()
 
                 elif remaining_time > 0:

--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -172,7 +172,8 @@ def simulate(saved, restart_after_mood_read=False):
                     logger.info("服务器维护中，DIO大人已为你暂停一切行动。")
                     logger.info("==============================================")
                     base_scheduler.handle_idle_action(remaining_time)
-                    base_scheduler.sleep(remaining_time)
+                    # 服务器维护期间 mower 完全空闲，同样走休眠收口点，让 /status 显示休眠
+                    base_scheduler._idle_sleep(remaining_time)
                     logger.info("时间开始流动了……DIO大人贴心为你重启时间！")
             if len(base_scheduler.tasks) > 0:
                 (base_scheduler.tasks.sort(key=lambda x: x.time, reverse=False))
@@ -261,34 +262,6 @@ def simulate(saved, restart_after_mood_read=False):
                             base_scheduler=base_scheduler,
                         )
                         base_scheduler.maa_plan_solver()
-                    else:
-                        remaining_time = (
-                            base_scheduler.tasks[0].time - datetime.now()
-                        ).total_seconds()
-                        subject = f"休息 {format_time(remaining_time)}，到{base_scheduler.tasks[0].time.strftime('%H:%M:%S')}开始工作"
-                        context = f"下一次任务:{base_scheduler.tasks[0].plan if len(base_scheduler.tasks[0].plan) != 0 else '空任务' if base_scheduler.tasks[0].type == '' else base_scheduler.tasks[0].type}"
-                        logger.info(context)
-                        logger.info(subject)
-                        base_scheduler.task_count += 1
-                        logger.info(f"第{base_scheduler.task_count}次任务结束")
-                        if remaining_time > 0:
-                            base_scheduler.handle_idle_action(remaining_time)
-                            body = task_template.render(
-                                tasks=[
-                                    obj.format(timezone_offset)
-                                    for obj in base_scheduler.tasks
-                                ],
-                                base_scheduler=base_scheduler,
-                            )
-                            send_message(
-                                body,
-                                f"休息 {format_time(remaining_time)}，到{base_scheduler.tasks[0].format(timezone_offset).time.strftime('%H:%M:%S')}开始工作",
-                            )
-                            base_scheduler.recog.last_scene = None
-                            base_scheduler.sleeping = True
-                            base_scheduler.sleep(remaining_time)
-                            base_scheduler.sleeping = False
-                            base_scheduler.check_current_focus()
 
                 elif remaining_time > 0:
                     now_time = datetime.now().time()
@@ -328,32 +301,7 @@ def simulate(saved, restart_after_mood_read=False):
                                 base_scheduler.tasks[0].time - datetime.now()
                             ).total_seconds()
 
-                    subject = f"休息 {format_time(remaining_time)}，到{base_scheduler.tasks[0].time.strftime('%H:%M:%S')}开始工作"
-                    context = f"下一次任务:{base_scheduler.tasks[0].plan}"
-                    logger.info(context)
-                    logger.info(subject)
-                    base_scheduler.task_count += 1
-                    logger.info(f"第{base_scheduler.task_count}次任务结束")
-                    if remaining_time > 300:
-                        if config.conf.close_simulator_when_idle:
-                            restart_simulator(start=False)
-                        elif config.conf.exit_game_when_idle:
-                            base_scheduler.device.exit()
-                    body = task_template.render(
-                        tasks=[
-                            obj.format(timezone_offset) for obj in base_scheduler.tasks
-                        ],
-                        base_scheduler=base_scheduler,
-                    )
-                    send_message(
-                        body,
-                        f"休息 {format_time(remaining_time)}，到{base_scheduler.tasks[0].format(timezone_offset).time.strftime('%H:%M:%S')}开始工作",
-                    )
-                    base_scheduler.recog.last_scene = None
-                    base_scheduler.sleeping = True
-                    base_scheduler.sleep(remaining_time)
-                    base_scheduler.sleeping = False
-                    base_scheduler.check_current_focus()
+                    base_scheduler.rest_until_next_task()
 
             base_scheduler._training_sm.gate_sync()
             result = base_scheduler.run()

--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -186,7 +186,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 logger.info(
                     f"出现任务调度情况休息{reschedule_time}秒等待下一个任务开始"
                 )
-                self.sleep(reschedule_time)
+                # 等待下一个任务开始也是任务间空闲，走唯一的休眠收口点维护 sleeping
+                self._idle_sleep(reschedule_time)
         if self.party_time is not None and self.party_time < datetime.now():
             self.party_time = None
         if self.free_clue is not None and self.free_clue != get_server_weekday():
@@ -4286,34 +4287,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     sf_solver = SecretFront(self.device, self.recog)
                     sf_solver.run(self.tasks[0].time - datetime.now())
 
-            remaining_time = (self.tasks[0].time - datetime.now()).total_seconds()
-            self.handle_idle_action(remaining_time)
-            subject = f"休息 {format_time(remaining_time)}，到{self.tasks[0].time.strftime('%H:%M:%S')}开始工作"
-            context = f"下一次任务:{self.tasks[0].plan if len(self.tasks[0].plan) != 0 else '空任务' if self.tasks[0].type == '' else self.tasks[0].type}"
-            logger.info(context)
-            logger.info(subject)
-            self.task_count += 1
-            logger.info(f"第{self.task_count}次任务结束")
-            timezone_offset = config.conf.timezone_offset
-            body = task_template.render(
-                tasks=[obj.format(timezone_offset) for obj in self.tasks],
-                base_scheduler=self,
-            )
-            send_message(
-                body,
-                f"休息 {format_time(remaining_time)}，到{self.tasks[0].format(timezone_offset).time.strftime('%H:%M:%S')}开始工作",
-            )
-            if remaining_time > 0:
-                if remaining_time > 300:
-                    if config.conf.close_simulator_when_idle:
-                        from arknights_mower.utils.simulator import restart_simulator
-
-                        restart_simulator(start=False)
-                    elif config.conf.exit_game_when_idle:
-                        self.device.exit()
-                self.recog.last_scene = None
-                self.sleep(remaining_time)
-                self.check_current_focus()
+            self.rest_until_next_task()
             self.MAA = None
         except MowerExit:
             if self.MAA is not None:
@@ -4331,7 +4305,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 logger.info(
                     f"休息 {format_time(remaining_time)}，到{self.tasks[0].time.strftime('%H:%M:%S')}开始工作"
                 )
-                self.sleep(remaining_time)
+                self._idle_sleep(remaining_time)
             self.check_current_focus()
 
     def skland_plan_solver(self):
@@ -4786,30 +4760,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     logger.info("local operation finished without executing any stage")
 
             scheduling(self.tasks)
-            remaining_time = (self.tasks[0].time - datetime.now()).total_seconds()
-            self.handle_idle_action(remaining_time)
-            subject = (
-                f"休息 {format_time(remaining_time)}，到"
-                f"{self.tasks[0].time.strftime('%H:%M:%S')}开始工作"
-            )
-            context = f"下一次任务:{self.tasks[0].plan if len(self.tasks[0].plan) != 0 else '空任务' if self.tasks[0].type == '' else self.tasks[0].type}"
-            logger.info(context)
-            logger.info(subject)
-            self.task_count += 1
-            logger.info(f"第{self.task_count}次任务结束")
-            timezone_offset = config.conf.timezone_offset
-            body = task_template.render(
-                tasks=[obj.format(timezone_offset) for obj in self.tasks],
-                base_scheduler=self,
-            )
-            send_message(
-                body,
-                f"休息 {format_time(remaining_time)}，到{self.tasks[0].format(timezone_offset).time.strftime('%H:%M:%S')}开始工作",
-            )
-            if remaining_time > 0:
-                self.recog.last_scene = None
-                self.sleep(remaining_time)
-                self.check_current_focus()
+            self.rest_until_next_task()
         except MowerExit:
             raise
         except Exception as e:
@@ -4822,7 +4773,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 logger.info(
                     f"休息 {format_time(remaining_time)}，到{self.tasks[0].time.strftime('%H:%M:%S')}开始工作"
                 )
-                self.sleep(remaining_time)
+                self._idle_sleep(remaining_time)
             self.check_current_focus()
 
     def mail_plan_solver(self):
@@ -5029,6 +4980,53 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 logger.info("自动更新合成配置完成")
         except Exception as e:
             logger.exception(f"自动安排专精/合成配置失败: {e}")
+
+    def _idle_sleep(self, remaining_time):
+        """任务之间真正的休眠——全工程里唯一维护 `sleeping` 状态的地方。
+
+        所有「等到下一个任务」的等待都必须经过这里，这样 /status 读到的
+        `sleeping` 永远和实际行为一致；以后新增休息路径也不可能再漏设标志。
+        用 try/finally 保证即使被 MowerExit（点停止）打断也能复位。
+        """
+        self.sleeping = True
+        try:
+            self.sleep(remaining_time)
+        finally:
+            self.sleeping = False
+
+    def rest_until_next_task(self):
+        """完成本轮任务后休息到 `tasks[0].time`，是调度器唯一的「任务间空闲」收尾。
+
+        发休息通知、累计任务计数、并真正睡到下个任务。
+        maa_plan_solver / mower_plan_solver / __main__ 主循环此前各自复制了
+        一份几乎相同的实现，其中两份漏掉了 `sleeping`，正是 /status 卡在
+        working 的根因。现在全部收口到这里，只有 `_idle_sleep` 一个状态写入点。
+        """
+        first = self.tasks[0]
+        remaining_time = (first.time - datetime.now()).total_seconds()
+        self.handle_idle_action(remaining_time)
+        timezone_offset = config.conf.timezone_offset
+        subject = (
+            f"休息 {format_time(remaining_time)}，到"
+            f"{first.time.strftime('%H:%M:%S')}开始工作"
+        )
+        context = f"下一次任务:{first.plan if len(first.plan) != 0 else '空任务' if first.type == '' else first.type}"
+        logger.info(context)
+        logger.info(subject)
+        self.task_count += 1
+        logger.info(f"第{self.task_count}次任务结束")
+        body = task_template.render(
+            tasks=[obj.format(timezone_offset) for obj in self.tasks],
+            base_scheduler=self,
+        )
+        send_message(
+            body,
+            f"休息 {format_time(remaining_time)}，到{first.format(timezone_offset).time.strftime('%H:%M:%S')}开始工作",
+        )
+        if remaining_time > 0:
+            self.recog.last_scene = None
+            self._idle_sleep(remaining_time)
+            self.check_current_focus()
 
     def handle_idle_action(self, remaining_time=0):
         if config.conf.close_simulator_when_idle and remaining_time > 300:


### PR DESCRIPTION
## 问题
mower 进入任务间休息后，`/status` 接口的 `sleeping` 仍为 `false`（调用方看到的是「运行中」而不是「休眠中」）。

根因：「休息到下一个任务」的收尾逻辑在 `base_schedule.py` 的 `maa_plan_solver` / `mower_plan_solver` 与 `__main__.py` 主循环里各复制了一份几乎相同的实现，但其中**只有部分**在 `sleep()` 前后设置了 `self.sleeping`。一旦走到没设置标志的那几条路径，`sleeping` 就一直是 `false`。

## 改动
- 新增 `_idle_sleep(remaining_time)`：**全工程唯一**维护 `sleeping` 的地方（`sleeping=True` → `sleep()` → `finally: sleeping=False`）。用 `try/finally` 保证即使被 `MowerExit`（点停止）打断也能复位。
- 新增 `rest_until_next_task()`：把各处重复的「休息收尾」（`handle_idle_action`、发通知、任务计数、睡到下个任务）收口成一个方法，内部走 `_idle_sleep`。
- 所有「等到下一个任务 / 服务器维护空闲」的等待都改走这两个收口点：
  - `base_schedule.py`：`maa_plan_solver` / `mower_plan_solver` 主体 → `rest_until_next_task()`；调度重排与异常分支的等待 → `_idle_sleep()`。
  - `__main__.py`：主循环休息 → `rest_until_next_task()`；DIO 服务器维护空闲 → `_idle_sleep()`；删除一段重复且漏设 `sleeping` 的死 `else` 分支。

净变化约 **−110 / +56** 行（去重）。以后再新增休息路径也不会漏设标志。

## 影响 / 兼容性
- `/status` 的 `sleeping` 与实际行为保持一致。
- 仅重构等待/休眠的收口，**不改变**休息时长、通知内容、`close_simulator_when_idle` / `exit_game_when_idle` 等既有行为。
