### PR TITLE
fix: 修复启动前 MAA 连通性检查时序

### DIFF
--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -26,18 +26,12 @@ base_scheduler = None
 # 执行自动排班
 def main(saved_state, restart_after_mood_read=False):
     logger.info("开始运行Mower")
-    if should_check_maa_before_start():
-        logger.info("启动前测试Maa连接")
-        result = run_maa_connectivity_check()
-        if result["status"] != "success":
-            logger.error(f"启动前Maa连接测试失败：{result['message']}")
-            return
-        logger.info(f"启动前Maa连接测试通过：{result['message']}")
+    startup_maa_check = should_check_maa_before_start()
     rapidocr.initialize_ocr()
     data = None
     if saved_state != {}:
         data = saved_state
-    result = simulate(data, restart_after_mood_read)
+    result = simulate(data, restart_after_mood_read, startup_maa_check)
     if result == "restart_after_mood_read":
         from arknights_mower.solvers.record import load_state
 
@@ -84,7 +78,7 @@ def initialize(
     return base_scheduler
 
 
-def simulate(saved, restart_after_mood_read=False):
+def simulate(saved, restart_after_mood_read=False, startup_maa_check=False):
     """
     具体调用方法可见各个函数的参数说明
     """
@@ -117,6 +111,14 @@ def simulate(saved, restart_after_mood_read=False):
                 continue
             else:
                 raise e
+    if startup_maa_check:
+        device_id = base_scheduler.device.client.device_id
+        logger.info(f"ADB连接已确认，启动前测试Maa连接：{device_id}")
+        result = run_maa_connectivity_check(adb=device_id)
+        if result["status"] != "success":
+            logger.error(f"启动前Maa连接测试失败：{result['message']}")
+            return
+        logger.info(f"启动前Maa连接测试通过：{result['message']}")
     # base_scheduler.仓库扫描() #别删了 方便我找
     validation_msg = base_scheduler.initialize_operators()
     if validation_msg is not None:

--- a/arknights_mower/tests/maa_startup_check_tests.py
+++ b/arknights_mower/tests/maa_startup_check_tests.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import arknights_mower.__main__ as mower_main
+
+
+class TestMaaStartupCheck(unittest.TestCase):
+    def test_check_runs_after_initialization_with_connected_device(self):
+        calls = []
+        scheduler = MagicMock()
+        scheduler.device.client.device_id = "connected-device"
+
+        def initialize(_tasks):
+            calls.append("initialize")
+            return scheduler
+
+        def run_maa_connectivity_check(*, adb):
+            calls.append(("maa_check", adb))
+            return {"status": "failed", "message": "failed"}
+
+        with (
+            patch.object(mower_main, "initialize", side_effect=initialize),
+            patch.object(
+                mower_main,
+                "run_maa_connectivity_check",
+                side_effect=run_maa_connectivity_check,
+            ),
+        ):
+            mower_main.simulate(None, startup_maa_check=True)
+
+        self.assertEqual(calls, ["initialize", ("maa_check", "connected-device")])
+        scheduler.initialize_operators.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/maa_check.py
+++ b/arknights_mower/utils/maa_check.py
@@ -38,11 +38,11 @@ print(json.dumps(result, ensure_ascii=False))
 """
 
 
-def maa_check_params() -> dict[str, str]:
+def maa_check_params(adb: str | None = None) -> dict[str, str]:
     return {
         "maa_path": str(config.conf.maa_path),
         "maa_adb_path": str(config.conf.maa_adb_path),
-        "adb": str(config.conf.adb),
+        "adb": str(config.conf.adb if adb is None else adb),
         "maa_conn_preset": str(config.conf.maa_conn_preset),
         "maa_touch_option": str(config.conf.maa_touch_option),
     }
@@ -87,10 +87,11 @@ def maa_check_timeout_result(timeout: int = MAA_CHECK_TIMEOUT) -> dict[str, str]
 
 def run_maa_connectivity_check(
     timeout: int = MAA_CHECK_TIMEOUT,
+    adb: str | None = None,
 ) -> dict[str, str]:
     try:
         result = subprocess.run(
-            maa_check_command(),
+            maa_check_command(maa_check_params(adb)),
             capture_output=True,
             text=True,
             timeout=timeout,


### PR DESCRIPTION
## 问题

启用“启动前检查 MAA 连接”后，连通性检查原先在 Mower 完成模拟器启动和 ADB 初始化前执行。当模拟器尚未启动或 ADB 需要恢复连接时，检查会提前失败并中断启动流程。

## 修改

- 沿用现有设备初始化流程，先完成模拟器自动启动和 ADB 建连，再执行一次 MAA 连通性检查
- 使用已连接设备的 `device_id` 作为检测目标，确保检测与后续 MAA 任务使用同一个 ADB 设备
- MAA 检测失败或超时时中断本次启动，不再继续初始化干员和调度任务
- 增加测试，覆盖检查执行顺序和设备 ID 传递

## 验证

- `python -m ruff check arknights_mower/__main__.py arknights_mower/utils/maa_check.py arknights_mower/tests/maa_startup_check_tests.py`
- `python -m ruff format --check arknights_mower/__main__.py arknights_mower/utils/maa_check.py arknights_mower/tests/maa_startup_check_tests.py`
- `python -m unittest arknights_mower.tests.maa_startup_check_tests`
- `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"`

Fixes #888
