### PR TITLE
fix(mastery): 修复专精调度死循环与 plan_key 前后端不一致

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -1975,35 +1975,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             try_workshop_tasks(self.op_data, self.tasks)
         if not self.find_next_task(datetime.now() + timedelta(minutes=5)):
             try_add_release_dorm({}, None, self.op_data, self.tasks)
-        pending = []
-        try:
-            from arknights_mower.utils.mastery_db import (
-                get_pending_plans,
-                has_in_progress_plan,
-            )
-
-            if has_in_progress_plan():
-                pass
-            else:
-                pending = get_pending_plans()
-        except Exception:
-            pass
-        if pending and not self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
-            from arknights_mower.utils.mastery_recommendation import get_skill_data
-
-            char_table = get_skill_data().get("characters", {})
-            entry = pending[0]
-            sk = str(entry["skill_index"] + 1)
-            char_info = char_table.get(entry["char_id"], {})
-            name = char_info.get("name", entry["char_id"])
-            t = SchedulerTask(
-                time=datetime.now(),
-                task_type=TaskTypes.SKILL_UPGRADE,
-                meta_data=f"{name} 技能{sk} -> 专精{entry.get('level', 1)} ",
-                adjusted=True,
-            )
-            t.plan_key = f"{entry['char_id']}_{entry['skill_index']}"
-            self.tasks.append(t)
+        # 专精计划由 MasterySync 统一调度（会同时生成上班任务和 SKILL_UPGRADE 任务）
+        # plan_solver 不再裸加 SKILL_UPGRADE 任务，避免和 MasterySync 冲突导致死循环
         if self.find_next_task(datetime.now() + timedelta(seconds=15)):
             logger.info("有其他任务,跳过宿舍纠错")
             return

--- a/arknights_mower/utils/mastery_db.py
+++ b/arknights_mower/utils/mastery_db.py
@@ -115,7 +115,7 @@ def get_pending_plans() -> list[dict]:
             "SELECT char_id, skill_index, MAX(id) as max_id "
             "FROM mastery_plan GROUP BY char_id, skill_index"
             ") latest ON p.id = latest.max_id "
-            "WHERE p.status IN ('pending', 'failed')"
+            "WHERE p.status = 'pending'"
         ).fetchall()
         return [dict(r) for r in rows]
     except Exception as e:

--- a/arknights_mower/utils/mastery_sync.py
+++ b/arknights_mower/utils/mastery_sync.py
@@ -149,12 +149,15 @@ class MasterySync:
                 )
                 return
 
+        # 先同步 cultivate.json 到 DB（自动完成已达成的等级）
+        # 必须在 SKILL_UPGRADE 检查之前，否则队列里残留的 SKILL_UPGRADE
+        # 会导致这里永远 return，_auto_complete_level3 不执行
+        pending = get_pending_only()
+        self._auto_complete_level3(pending)
+
         if self._scheduler.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
             logger.debug("MasterySync: queue already has SKILL_UPGRADE, skip cycle")
             return
-
-        pending = get_pending_only()
-        self._auto_complete_level3(pending)
 
         remaining = get_pending_only()
         if not remaining:
@@ -242,6 +245,11 @@ class MasterySync:
             logger.warning(f"MasterySync: check building_training failed: {e}")
 
     def _auto_complete_level3(self, pending):
+        """根据 cultivate.json 中的实际专精等级，自动完成已达成 level 的计划。
+
+        如果干员当前专精等级高于计划目标等级，自动补完中间等级并创建下一级 pending。
+        例如：干员已是专精2，计划 level=1 → 自动完成 level=1，创建 pending level=3。
+        """
         cultivate_path = get_path("@app/tmp/cultivate.json")
         if not _os.path.exists(cultivate_path):
             return
@@ -256,12 +264,35 @@ class MasterySync:
             for idx, s in enumerate(char.get("skills", [])):
                 lvl = s.get("level", 0) or 0
                 char_levels[f"{cid}_{idx}"] = lvl
+
+        def _skip_to_level(p, target_lvl: int):
+            plan_lvl = p.get("level", 1)
+            if target_lvl >= 3:
+                logger.info(
+                    f"MasterySync: {p['char_id']}_{p['skill_index']} "
+                    f"already at level={target_lvl} >= 3, marking completed"
+                )
+                insert_plan(
+                    p["char_id"], p["skill_index"], "completed", level=target_lvl
+                )
+            elif target_lvl >= plan_lvl:
+                logger.info(
+                    f"MasterySync: {p['char_id']}_{p['skill_index']} "
+                    f"already at level={target_lvl} (plan level={plan_lvl}), "
+                    f"auto-completing and adding pending level={target_lvl + 1}"
+                )
+                insert_plan(
+                    p["char_id"], p["skill_index"], "completed", level=target_lvl
+                )
+                insert_plan(
+                    p["char_id"], p["skill_index"], "pending", level=target_lvl + 1
+                )
+
         for p in pending:
             key = f"{p['char_id']}_{p['skill_index']}"
             lvl = char_levels.get(key, 0)
-            if lvl >= 3:
-                logger.info(f"MasterySync: {key} level={lvl} >= 3, marking completed")
-                insert_plan(p["char_id"], p["skill_index"], "completed", level=lvl)
+            if lvl >= p.get("level", 1):
+                _skip_to_level(p, lvl)
 
         in_progress = [p for p in get_all_plans() if p["status"] == "in_progress"]
         if in_progress:
@@ -325,7 +356,8 @@ class MasterySync:
                 adjusted=True,
             )
             t.plan_key = f"{char_id}_{skill_index}"
-            self._scheduler.tasks.insert(0, t)
+            # 专精任务必须在上班任务之后执行，否则训练室没人
+            self._scheduler.tasks.append(t)
             logger.info(f"MasterySync: scheduled {name} 技能{sk}")
         except Exception as e:
             logger.exception(

--- a/server.py
+++ b/server.py
@@ -1147,41 +1147,43 @@ def add_task():
                         if has_train_group_plan():
                             raise Exception("训练室已设置小组轮换，无法添加专精任务")
                         pk = task.get("plan_key", "")
-                        if not pk:
-                            raise Exception("专精任务缺少 plan_key")
-                        parts = pk.rsplit("_", 1)
-                        if len(parts) != 2:
-                            raise Exception("plan_key 格式错误")
-                        char_id = parts[0]
-                        from arknights_mower.utils.mastery_recommendation import (
-                            PROF_MAP,
-                            _supports_from_dicts,
-                            get_skill_data,
-                        )
-
-                        char_table = get_skill_data().get("characters", {})
-                        prof_en = char_table.get(char_id, {}).get("profession", "")
-                        if not prof_en:
-                            raise Exception(f"未找到干员 {char_id} 的职业信息")
-                        prof_cn = PROF_MAP.get(prof_en, prof_en)
-                        route = get_route(prof_cn)
-                        if not route:
-                            raise Exception(
-                                f"未配置 {prof_cn} 的专精路线，请先在专精路线设置中保存"
+                        if pk:
+                            parts = pk.rsplit("_", 1)
+                            if len(parts) != 2:
+                                raise Exception("plan_key 格式错误")
+                            char_id = parts[0]
+                            from arknights_mower.utils.mastery_recommendation import (
+                                PROF_MAP,
+                                _supports_from_dicts,
+                                get_skill_data,
                             )
-                        import json as _json
 
-                        parsed = _json.loads(route["supports"])
-                        supports_list = (
-                            parsed.get("supports", [])
-                            if isinstance(parsed, dict)
-                            else parsed
-                        )
-                        if not supports_list:
-                            raise Exception(f"{prof_cn} 的专精路线为空")
-                        supports = _supports_from_dicts(supports_list)
-                        base_scheduler.op_data.skill_upgrade_supports = supports
-                        logger.info(f"从数据库加载 {prof_cn} 专精路线完毕")
+                            char_table = get_skill_data().get("characters", {})
+                            prof_en = char_table.get(char_id, {}).get("profession", "")
+                            if not prof_en:
+                                raise Exception(f"未找到干员 {char_id} 的职业信息")
+                            prof_cn = PROF_MAP.get(prof_en, prof_en)
+                            route = get_route(prof_cn)
+                            if not route:
+                                raise Exception(
+                                    f"未配置 {prof_cn} 的专精路线，请先在专精路线设置中保存"
+                                )
+                            import json as _json
+
+                            parsed = _json.loads(route["supports"])
+                            supports_list = (
+                                parsed.get("supports", [])
+                                if isinstance(parsed, dict)
+                                else parsed
+                            )
+                            if not supports_list:
+                                raise Exception(f"{prof_cn} 的专精路线为空")
+                            supports = _supports_from_dicts(supports_list)
+                            base_scheduler.op_data.skill_upgrade_supports = supports
+                            new_task.plan_key = pk
+                            logger.info(f"从数据库加载 {prof_cn} 专精路线完毕")
+                        else:
+                            logger.info("plan_key 未提供，跳过专精路线自动加载")
                     base_scheduler.tasks.append(new_task)
                     logger.debug(f"成功：{str(new_task)}")
                     return "添加任务成功！"

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -1139,7 +1139,8 @@ async function doAddTask() {
         time: new Date(Date.now() + 120000).toISOString(),
         plan: {},
         task_type: '技能专精',
-        meta_data: '' + skillNum
+        meta_data: '' + skillNum,
+        plan_key: planKey(op.char_id, rec.skill_index)
       },
       upgrade_support: supports
     })


### PR DESCRIPTION
## 问题

全自动专精在部分场景下会：

1. **训练室空转 / 任务死循环**：`plan_solver` 裸加 `SKILL_UPGRADE`，`MasterySync` 见队列已有专精任务就直接 return，`_auto_complete_level3` 永远不跑；同时 `SKILL_UPGRADE` 被 `insert(0)` 插到上班任务之前，进训练室时人还没到位。
2. **failed 计划反复进队**：`get_pending_plans()` 的 SQL 包含 `failed`，失败项被反复调度。
3. **中间等级不跳过**：干员已是专精 2、计划仍是 level=1 时，不会自动补完并推进。
4. **推荐页加专精任务失败**：#886 后后端要求 `plan_key`，但 `MasteryRecommendation.vue` 的 `doAddTask` 未传；即使传了，后端也未把 `plan_key` 写到 task 对象上，完成态回写会丢。

## 改动

| 文件 | 变更 |
|------|------|
| `mastery_db.py` | `get_pending_plans` 只查 `pending` |
| `mastery_sync.py` | 先 `_auto_complete_level3`；支持中间等级跳过；`SKILL_UPGRADE` 改为 `append`（在上班之后） |
| `base_schedule.py` | `plan_solver` 删除裸加 `SKILL_UPGRADE`，统一交给 `MasterySync` |
| `MasteryRecommendation.vue` | `doAddTask` 增加 `plan_key: planKey(char_id, skill_index)` |
| `server.py` | 有 `plan_key` 时加载专精路线并设置 `new_task.plan_key`；无则跳过路线加载（兼容 TaskDialog 等入口） |

## plan_key 语义（避免误解）

- 格式：`{char_id}_{skill_index}`（skill_index 从 0 起）
- **用途**：添加「技能专精」任务时，用 char_id 查职业 → 拉该职业专精路线（协助干员）写入 `skill_upgrade_supports`；执行时用 task 上的 `plan_key` 回写 DB 完成/失败
- **不是**：排班 plan / 周计划 key
- 本 PR：推荐页主路径**始终传**；后端对缺失做兼容，不强制 raise

## 测试

- [ ] 有 pending 计划时，任务队列顺序为：上班(train) → SKILL_UPGRADE
- [ ] failed 计划不会被 `get_pending_plans` 再次拉起（需手动重试）
- [ ] 干员已专精 2、DB pending level=1 时，会自动推进到下一级 pending
- [ ] 专精推荐页「添加专精任务」成功，日志出现「从数据库加载 xx 专精路线完毕」
- [ ] 无 plan_key 的手动添加不再直接报错（跳过路线自动加载）

## 说明

基于手机端长期运行踩坑的修复；未包含 `swap` 字段、workshop `planned_skills` 等，可另开 PR。