### PR TITLE
fix: 最小化修复无法停止问题

### DIFF
--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -149,9 +149,6 @@ def simulate(saved, restart_after_mood_read=False, startup_maa_check=False):
             base_scheduler.op_data.skill_upgrade_supports = saved[
                 "skill_upgrade_supports"
             ]
-            base_scheduler._completed_masteries = saved.get(
-                "_completed_masteries", set()
-            )
             base_scheduler.tasks = tasks
             if len(base_scheduler.op_data.backup_plans) > 0:
                 # 启动的时候按照条件触发副表

--- a/arknights_mower/solvers/record.py
+++ b/arknights_mower/solvers/record.py
@@ -97,7 +97,6 @@ def current_state():
         "daily_mail": base_scheduler.daily_mail,
         "task_count": base_scheduler.task_count,
         "skill_upgrade_supports": base_scheduler.op_data.skill_upgrade_supports,
-        "_completed_masteries": base_scheduler._completed_masteries,
     }
 
 


### PR DESCRIPTION
## 问题

专精状态重构删除了调度器的 `_completed_masteries` 初始化，但状态保存和恢复仍然访问该字段。

`/stop` 的状态保存装饰器会在设置停止事件前调用 `current_state()`，因此缺失字段会触发 `AttributeError` 并返回 500，Mower 线程没有收到停止信号。

## 修改

- 从当前状态快照中移除已废弃的 `_completed_masteries`
- 从缓存恢复流程中移除该字段的恢复逻辑
- 旧缓存即使包含该字段也会被自然忽略，无需清空缓存
- 不修改 `/stop` 接口、前端和专精调度逻辑

## 验证

- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m unittest discover -s arknights_mower/tests -p "*_tests.py"`（42 项通过）
- 使用不含 `_completed_masteries` 的模拟调度器验证 `current_state()` 正常生成状态
- 使用 Flask 测试客户端和模拟 Mower 线程验证 `/stop` 返回 `true`、设置停止事件并记录“成功停止mower线程”

说明：完整 unittest 仍会输出既有的 `news_checker` 日志格式报错，但测试结果为 OK。