### PR TITLE
fix(mastery): 尊重 swap=false，并传入 planned_skills 生成合成配置

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -1147,7 +1147,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 ),
                 None,
             )
-            if not support or support.name == support.swap_name:
+            if not support or not support.swap:
                 return
 
             h = self.op_data.calculate_switch_time(support, hour=remaining_h)

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -280,7 +280,10 @@ def get_mastery_recommendations():
 
 
 def compute_workshop_config(
-    fodder_operators=None, t5_operators=None, book_operators=None
+    fodder_operators=None,
+    t5_operators=None,
+    book_operators=None,
+    planned_skills=None,
 ):
     """根据当前专精计划和仓库库存，计算合成配置（与前端自动合成配置逻辑一致）"""
     if fodder_operators is None:
@@ -293,15 +296,19 @@ def compute_workshop_config(
 
     from arknights_mower.data import workshop_formula
 
-    plan_path = get_path("@app/tmp/matery_plan.json")
-    planned_keys = []
-    if os.path.exists(plan_path):
-        try:
-            with open(plan_path, "r", encoding="utf-8") as f:
-                plan = json.load(f)
-            planned_keys = [k for k, v in plan.items() if v]
-        except Exception:
-            pass
+    # 优先用前端传入的 planned_skills；否则回退读文件（文件名历史拼写 matery）
+    if planned_skills is not None:
+        planned_keys = list(planned_skills)
+    else:
+        plan_path = get_path("@app/tmp/matery_plan.json")
+        planned_keys = []
+        if os.path.exists(plan_path):
+            try:
+                with open(plan_path, "r", encoding="utf-8") as f:
+                    plan = json.load(f)
+                planned_keys = [k for k, v in plan.items() if v]
+            except Exception:
+                pass
 
     if planned_keys:
         try:
@@ -589,6 +596,7 @@ def _supports_from_dicts(supports_data):
             efficiency=s["efficiency"],
             match=s.get("match", False),
             swap_name=s.get("swap_name", s["name"]),
+            swap=s.get("swap", True),
         )
         supports.append(sup)
     return supports

--- a/arknights_mower/utils/operators.py
+++ b/arknights_mower/utils/operators.py
@@ -105,13 +105,17 @@ class SkillUpgradeSupport:
     use_booster = True
     name = ""
     swap_name = ""
+    swap = True
 
-    def __init__(self, name, skill_level, efficiency, match, swap_name="艾丽妮"):
+    def __init__(
+        self, name, skill_level, efficiency, match, swap_name="艾丽妮", swap=True
+    ):
         self.name = name
         self.level = skill_level
         self.efficiency = efficiency
         self.match = match
         self.swap_name = swap_name
+        self.swap = swap
 
 
 class Operators:

--- a/server.py
+++ b/server.py
@@ -906,6 +906,7 @@ def workshop_auto_config():
                 fodder_operators=fodder_ops,
                 t5_operators=t5_ops,
                 book_operators=book_ops,
+                planned_skills=planned_skills,
             )
         else:
             settings = compute_default_workshop_config(


### PR DESCRIPTION
## 问题

1. **专精路线 `swap=false` 被忽略**  
   路线 JSON 里可配置某协助干员不换人（如望），但 `SkillUpgradeSupport` 没有 `swap` 字段，`_calculate_swap_from_api` 用 `name == swap_name` 判断，导致仍会排减半换人。

2. **自动合成配置失败**  
   前端 `/workshop-auto-config` 已传 `planned_skills`，server 读到后没有传给 `compute_workshop_config`；函数内部只读不存在的 `tmp/matery_plan.json`，返回 `null`，页面报「生成失败」。

## 改动

| 文件 | 变更 |
|------|------|
| `operators.py` | `SkillUpgradeSupport` 增加 `swap`（默认 `True`） |
| `mastery_recommendation.py` | `_supports_from_dicts` 传递 `swap`；`compute_workshop_config(..., planned_skills=None)` 优先用参数 |
| `base_schedule.py` | `_calculate_swap_from_api` 改为 `not support.swap` 时跳过 |
| `server.py` | `workshop_auto_config` 传入 `planned_skills=planned_skills` |

## 测试

- [ ] 专精路线中某协助位 `swap: false` 时，训练中不再为其生成减半换人任务
- [ ] 专精推荐页选择计划技能后点「自动合成配置」能生成 `workshop_settings`（非 null）
- [ ] 不传 `planned_skills` 时仍回退读 `matery_plan.json`（兼容旧调用）

## 关联

与 #891（调度 / plan_key）独立，可分开 review。