### PR TITLE
fix: verify_agent 识别不匹配时重试读屏，避免基建换班反复失败

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Unrelease]
 - fix: 修复启动前 MAA 连通性检查时序 [#889](https://github.com/ArkMowers/arknights-mower/pull/889/changes#diff-d6ca44bc67dfb7f8f8516a6b8d8fb0a6ac79dcdb080452b3e86a594b57998eaf) [@ALEXsun0](https://github.com/alexsun0)
+- fix: verify_agent 识别不匹配时重试读屏，避免基建换班反复报「检测到干员选择错误」 [#898](https://github.com/ArkMowers/arknights-mower/pull/898) [@clousky2020](https://github.com/clousky2020)
 
 ## v4.1.5.7 - 2026-07-10
 

--- a/arknights_mower/solvers/base_mixin.py
+++ b/arknights_mower/solvers/base_mixin.py
@@ -172,6 +172,7 @@ class BaseMixin:
         max_agent_count=-1,
         full_scan=True,
         train=False,
+        retry=0,
     ):
         try:
             # 识别干员
@@ -189,6 +190,24 @@ class BaseMixin:
                 if index >= len(agent):
                     return True
                 if name != agent[index]:
+                    # 单次识别可能因界面动画未稳定 / 模板匹配置信度低（operator_list 低置信返回空串）
+                    # 而误判为选择错误，这里重试读屏而非直接判定失败
+                    if retry < 2:
+                        logger.debug(
+                            f"verify_agent 第 {retry + 1} 次匹配失败"
+                            f"({name!r} != {agent[index]!r})，重试读屏"
+                        )
+                        self.sleep(0.5)
+                        self.recog.update()
+                        return self.verify_agent(
+                            agent,
+                            room,
+                            error_count,
+                            max_agent_count,
+                            full_scan=False,
+                            train=train,
+                            retry=retry + 1,
+                        )
                     return False
                 index += 1
             return True
@@ -198,7 +217,13 @@ class BaseMixin:
                 self.switch_arrange_order("技能", room)
             if error_count < 3:
                 return self.verify_agent(
-                    agent, room, error_count, max_agent_count, full_scan=False
+                    agent,
+                    room,
+                    error_count,
+                    max_agent_count,
+                    full_scan=False,
+                    train=train,
+                    retry=retry,
                 )
             else:
                 logger.exception(e)


### PR DESCRIPTION
## 问题

基建换班（`agent_arrange_room` → `choose_agent`）选择干员后会调用 `verify_agent` 回读屏幕校验。在部分运行（尤其 AVD / 模拟器环境，以及日志中可见的 2024-09 旧日志）中，该步骤会反复报：

```
ERROR agent_arrange_room: 检测到干员选择错误，重新选择
ERROR infra_main: 重试一次
```

`verify_agent`（`base_mixin.py`）的判定逻辑是：对 `operator_list(self.recog.img)` 返回的干员名逐个与计划比对，一旦 `name != agent[index]` 立即 `return False`。

## 根因

`operator_list`（`character_recognize.py:21`）使用模板匹配，当匹配置信度 ≤ 0.6 时返回空串 `""`。因此：

- 选完干员后**单次**读屏，若恰好界面动画未稳定、或某干员名模板匹配置信度偏低返回空串，就会让 `name != agent[index]` 成立；
- 而 `verify_agent` 对「名字不匹配」**没有任何重试**（只有 `Exception` 才会走 `error_count` 重试），于是直接判定失败；
- 上层 `agent_arrange_room` / `infra_main` 不断重试，表现为长时间循环。

## 修复

在 `verify_agent` 中，对「识别名字与计划不匹配」的情况增加读屏重试：短暂等待界面稳定后重新 `recog.update()` 并重新识别，最多 2 次。

- 仅对**偶发性**识别/动画未稳定不一致生效，能显著减少无谓的换班失败与循环；
- 对于**持续性**逻辑错位（如屏幕本身显示的就是候选面板而非已选干员），最终仍会判定失败并抛出异常，行为与修改前一致，不会掩盖真实问题；
- 异常路径（`error_count` 重试）保持不变。

## 影响范围

仅修改 `verify_agent` 失败路径，非 AVD 环境的默认触控与 CSV 编码逻辑均不受影响。此修复独立于 `feat/avd-support-and-encoding-fix`，单独成 PR 以免污染该分支。

## 备注

本修复针对的是「瞬时识别/动画未稳定」场景。若后续发现某房间（如会客室 `meeting`）存在**持续性**的屏幕读取错位（verify 读到的始终是候选面板而非已选干员），那属于 `choose_agent` 选择/排序逻辑的更深问题，需要单独排查，不在本 PR 内解决。