### PR TITLE
fix: 修复错误的创建专精任务，应该使用MasterySync正确地创建任务

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -2005,21 +2005,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         except Exception:
             pass
         if pending and not self.find_next_task(task_type=TaskTypes.SKILL_UPGRADE):
-            from arknights_mower.utils.mastery_recommendation import get_skill_data
+            from arknights_mower.utils.mastery_sync import MasterySync
 
-            char_table = get_skill_data().get("characters", {})
-            entry = pending[0]
-            sk = str(entry["skill_index"] + 1)
-            char_info = char_table.get(entry["char_id"], {})
-            name = char_info.get("name", entry["char_id"])
-            t = SchedulerTask(
-                time=datetime.now(),
-                task_type=TaskTypes.SKILL_UPGRADE,
-                meta_data=f"{name} 技能{sk} -> 专精{entry.get('level', 1)} ",
-                adjusted=True,
-            )
-            t.plan_key = f"{entry['char_id']}_{entry['skill_index']}"
-            self.tasks.append(t)
+            MasterySync(self)._schedule_next(pending[0])
         if self.find_next_task(datetime.now() + timedelta(seconds=15)):
             logger.info("有其他任务,跳过宿舍纠错")
             return


### PR DESCRIPTION
## 问题描述

当专精计划从一个职业切换到另一个职业，并在执行前重启主进程时，恢复逻辑会直接创建 `SKILL_UPGRADE` 任务，但不会根据当前干员职业重新加载专精路线和协助位配置。

这会导致调度器继续使用上一个职业遗留的 `skill_upgrade_supports`，从而出现专精配置与当前干员职业不匹配的问题。

## 修改内容

- 将 `MasterySync` 中完整的专精建单逻辑复用于重启恢复流程。
- 恢复 pending/failed 专精计划时，根据当前干员职业：
  - 重新读取对应的专精路线；
  - 替换 `skill_upgrade_supports`；
  - 创建训练室协助位任务；
  - 创建带有正确 `plan_key` 的 `SKILL_UPGRADE` 任务。
- 保留原有的专精计划恢复、异常处理和状态管理逻辑。

## 影响范围

仅影响专精计划在主进程重启后的恢复调度，不改变正常专精流程及其他基建任务的调度行为。